### PR TITLE
Adds support for multi-options execution.

### DIFF
--- a/amazon/ionbenchmark/API.py
+++ b/amazon/ionbenchmark/API.py
@@ -6,3 +6,4 @@ class API(Enum):
     """Enumeration of the APIs."""
     SIMPLE_ION = 'simple_ion'
     EVENT = 'event'
+    DEFAULT = 'simple_ion'

--- a/amazon/ionbenchmark/Format.py
+++ b/amazon/ionbenchmark/Format.py
@@ -5,3 +5,4 @@ class Format(Enum):
     """Enumeration of the formats."""
     ION_TEXT = 'ion_text'
     ION_BINARY = 'ion_binary'
+    DEFAULT = 'ion_binary'

--- a/amazon/ionbenchmark/ion_benchmark_cli.py
+++ b/amazon/ionbenchmark/ion_benchmark_cli.py
@@ -410,6 +410,8 @@ def ion_python_benchmark_cli(arguments):
                                                 c_extension, binary, file, each_option)
         print(tabulate(table, tablefmt='fancy_grid'))
 
+    return table
+
 
 if __name__ == '__main__':
     ion_python_benchmark_cli(docopt(__doc__, help=True))

--- a/amazon/ionbenchmark/ion_benchmark_cli.py
+++ b/amazon/ionbenchmark/ion_benchmark_cli.py
@@ -180,6 +180,7 @@ def read_micro_benchmark_simpleion(iterations, warmups, c_extension, file, memor
 
 
 # Benchmarks pure python implementation event based APIs
+# https://github.com/amazon-ion/ion-python/issues/236
 def read_micro_benchmark_event(iterations, warmups, c_extension, file, memory_profiling, iterator=False):
     return 0, 0, 0
 
@@ -264,6 +265,7 @@ def write_micro_benchmark_simpleion(iterations, warmups, c_extension, obj, file,
 
 
 # Benchmarks pure python event based write API
+# https://github.com/amazon-ion/ion-python/issues/236
 def write_micro_benchmark_event(iterations, warmups, c_extension, obj, file, binary, memory_profiling):
     return 0, 0
 
@@ -354,11 +356,11 @@ def ion_python_benchmark_cli(arguments):
     c_extension = str_to_bool(arguments['--c-extension']) if not pypy else False
     iterator = str_to_bool(arguments['--iterator'])
 
-    # Note. For future multi-execution options, initialize them as below and added them into option_configuration.
+    # For options may show up more than once, initialize them as below and added them into list option_configuration.
     # initialize options that might show up multiple times
     api = [*set(arguments['--api'])] if arguments['--api'] else [API.DEFAULT.value]
     format_option = [*set(arguments['--format'])] if arguments['--format'] else [Format.DEFAULT.value]
-    # option_configuration is used for tracking multi-execution options
+    # option_configuration is used for tracking options may show up multiple times.
     option_configuration = [api, format_option]
     option_configuration_combination = list(itertools.product(*option_configuration))
 

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -136,6 +136,8 @@ def test_option_write_iterations(file=generate_test_path('integers.ion')):
 def gather_all_options_in_list(table):
     rtn = []
     count = 1
+    if len(table) < 1:
+        return []
     while count < len(table):
         rtn += [table[count][1]]
         count += 1
@@ -144,6 +146,7 @@ def gather_all_options_in_list(table):
 
 def test_read_multi_api(file=generate_test_path('integers.ion')):
     table = execution_with_command(['read', file, '--api', 'simple_ion', '--api', 'event'])
+    assert gather_all_options_in_list(table) == sorted([('event', 'ion_binary'), ('simple_ion', 'ion_binary')])
 
 
 def test_write_multi_api(file=generate_test_path('integers.ion')):

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -1,13 +1,13 @@
 import time
 from itertools import chain
-from os.path import abspath, join, dirname, getsize
+from os.path import abspath, join, dirname
 
 from docopt import docopt
 
 from amazon.ion import simpleion
 from amazon.ionbenchmark import ion_benchmark_cli
-from amazon.ionbenchmark.ion_benchmark_cli import generate_simpleion_load_test_code, generate_simpleion_dump_test_code, \
-    BYTES_TO_MB, ion_python_benchmark_cli
+from amazon.ionbenchmark.ion_benchmark_cli import generate_simpleion_load_test_code, generate_simpleion_dump_test_code,\
+    ion_python_benchmark_cli
 from amazon.ionbenchmark.util import str_to_bool, TOOL_VERSION
 from tests import parametrize
 from tests.test_simpleion import generate_scalars_text
@@ -79,44 +79,22 @@ def test_option_version():
 
 
 def test_option_write(file=generate_test_path('integers.ion')):
-    # make sure it reads successfully
-    file_size, result_with_gc, write_memory_usage_peak = \
-        execution_with_command(['write', file])
-
-    assert file_size == getsize(file) / BYTES_TO_MB
-    assert result_with_gc > 0
-    assert write_memory_usage_peak >= 0
+    execution_with_command(['write', file])
 
 
 def test_option_read(file=generate_test_path('integers.ion')):
     # make sure it reads successfully
-    file_size, result_with_gc, conversion_time, read_memory_usage_peak = \
-        execution_with_command(['read', file])
-
-    assert file_size == getsize(file) / BYTES_TO_MB
-    assert result_with_gc > 0
-    assert read_memory_usage_peak >= 0
+    execution_with_command(['read', file])
 
 
 def test_option_write_c_extension(file=generate_test_path('integers.ion')):
-    file_size, result_with_gc, write_memory_usage_peak = \
-        execution_with_command(['write', file, '--c-extension', 'true'])
-
-    file_size_2, result_with_gc_2, write_memory_usage_peak_2 = \
-        execution_with_command(['write', file, '--c-extension', 'false'])
-
-    assert file_size == getsize(file) / BYTES_TO_MB
-    assert file_size_2 == getsize(file) / BYTES_TO_MB
+    execution_with_command(['write', file, '--c-extension', 'true'])
+    execution_with_command(['write', file, '--c-extension', 'false'])
 
 
 def test_option_read_c_extension(file=generate_test_path('integers.ion')):
-    file_size, result_with_gc, conversion_time, read_memory_usage_peak = \
-        execution_with_command(['read', file, '--c-extension', 'true'])
-
-    file_size_2, result_with_gc_2, conversion_time_2, read_memory_usage_peak_2 = \
-        execution_with_command(['read', file, '--c-extension', 'false'])
-
-    assert file_size == getsize(file) / BYTES_TO_MB
+    execution_with_command(['read', file, '--c-extension', 'true'])
+    execution_with_command(['read', file, '--c-extension', 'false'])
 
 
 def test_option_read_iterations(file=generate_test_path('integers.ion')):
@@ -154,3 +132,34 @@ def test_option_write_iterations(file=generate_test_path('integers.ion')):
     # Executing 100 times should be longer than benchmark only once, but don't have to be exact 100x faster.
     assert time_2 > time_1
 
+
+def test_read_multi_api(file=generate_test_path('integers.ion')):
+    execution_with_command(['read', file, '--api', 'simple_ion', '--api', 'event'])
+
+
+def test_write_multi_api(file=generate_test_path('integers.ion')):
+    execution_with_command(['write', file, '--api', 'simple_ion', '--api', 'event'])
+
+
+def test_read_multi_duplicated_api(file=generate_test_path('integers.ion')):
+    execution_with_command(['read', file, '--api', 'simple_ion', '--api', 'event', '--api', 'event'])
+
+
+def test_write_multi_duplicated_api(file=generate_test_path('integers.ion')):
+    execution_with_command(['write', file, '--api', 'simple_ion', '--api', 'event', '--api', 'event'])
+
+
+def test_read_multi_format(file=generate_test_path('integers.ion')):
+    execution_with_command(['read', file, '--format', 'ion_text', '--format', 'ion_binary'])
+
+
+def test_write_multi_format(file=generate_test_path('integers.ion')):
+    execution_with_command(['write', file, '--format', 'ion_text', '--format', 'ion_binary'])
+
+
+def test_read_multi_duplicated_format(file=generate_test_path('integers.ion')):
+    execution_with_command(['read', file, '--format', 'ion_text', '--format', 'ion_binary', '--format', 'ion_text'])
+
+
+def test_write_multi_duplicated_format(file=generate_test_path('integers.ion')):
+    execution_with_command(['write', file, '--format', 'ion_text', '--format', 'ion_binary', '--format', 'ion_text',])

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -133,33 +133,49 @@ def test_option_write_iterations(file=generate_test_path('integers.ion')):
     assert time_2 > time_1
 
 
+def gather_all_options_in_list(table):
+    rtn = []
+    count = 1
+    while count < len(table):
+        rtn += [table[count][1]]
+        count += 1
+    return sorted(rtn)
+
+
 def test_read_multi_api(file=generate_test_path('integers.ion')):
-    execution_with_command(['read', file, '--api', 'simple_ion', '--api', 'event'])
+    table = execution_with_command(['read', file, '--api', 'simple_ion', '--api', 'event'])
 
 
 def test_write_multi_api(file=generate_test_path('integers.ion')):
-    execution_with_command(['write', file, '--api', 'simple_ion', '--api', 'event'])
+    table = execution_with_command(['write', file, '--api', 'simple_ion', '--api', 'event'])
+    assert gather_all_options_in_list(table) == sorted([('event', 'ion_binary'), ('simple_ion', 'ion_binary')])
 
 
 def test_read_multi_duplicated_api(file=generate_test_path('integers.ion')):
-    execution_with_command(['read', file, '--api', 'simple_ion', '--api', 'event', '--api', 'event'])
+    table = execution_with_command(['read', file, '--api', 'simple_ion', '--api', 'event', '--api', 'event'])
+    assert gather_all_options_in_list(table) == sorted([('event', 'ion_binary'), ('simple_ion', 'ion_binary')])
 
 
 def test_write_multi_duplicated_api(file=generate_test_path('integers.ion')):
-    execution_with_command(['write', file, '--api', 'simple_ion', '--api', 'event', '--api', 'event'])
+    table = execution_with_command(['write', file, '--api', 'simple_ion', '--api', 'event', '--api', 'event'])
+    assert gather_all_options_in_list(table) == sorted([('event', 'ion_binary'), ('simple_ion', 'ion_binary')])
 
 
 def test_read_multi_format(file=generate_test_path('integers.ion')):
-    execution_with_command(['read', file, '--format', 'ion_text', '--format', 'ion_binary'])
+    table = execution_with_command(['read', file, '--format', 'ion_text', '--format', 'ion_binary'])
+    assert gather_all_options_in_list(table) == sorted([('simple_ion', 'ion_binary'), ('simple_ion', 'ion_text')])
 
 
 def test_write_multi_format(file=generate_test_path('integers.ion')):
-    execution_with_command(['write', file, '--format', 'ion_text', '--format', 'ion_binary'])
+    table = execution_with_command(['write', file, '--format', 'ion_text', '--format', 'ion_binary'])
+    assert gather_all_options_in_list(table) == sorted([('simple_ion', 'ion_text'), ('simple_ion', 'ion_binary')])
 
 
 def test_read_multi_duplicated_format(file=generate_test_path('integers.ion')):
-    execution_with_command(['read', file, '--format', 'ion_text', '--format', 'ion_binary', '--format', 'ion_text'])
+    table = execution_with_command(['read', file, '--format', 'ion_text', '--format', 'ion_binary', '--format', 'ion_text'])
+    assert gather_all_options_in_list(table) == sorted([('simple_ion', 'ion_text'), ('simple_ion', 'ion_binary')])
 
 
 def test_write_multi_duplicated_format(file=generate_test_path('integers.ion')):
-    execution_with_command(['write', file, '--format', 'ion_text', '--format', 'ion_binary', '--format', 'ion_text',])
+    table = execution_with_command(['write', file, '--format', 'ion_text', '--format', 'ion_binary', '--format', 'ion_text',])
+    assert gather_all_options_in_list(table) == sorted([('simple_ion', 'ion_text'), ('simple_ion', 'ion_binary')])


### PR DESCRIPTION
## Description:

This PR adds support for multi-options execution - https://github.com/amazon-ion/ion-python/issues/226. 

For example, user provides `--api simple_ion`, `--api event`, `--format ion_text` and `--format ion_binary`. the CLI tool will generates combinations of all these two options (`--api` and `--format`) and execute each of them. 

E.g. the report should be something like 
|options|result|
|---|---|
|`--api simple_ion`,`--format ion_binary` |15s|
|`--api simple_ion`,`--format ion_text`|12s|
|`--api event`,`--format ion_binary`|15s|
|`--api event`,`--format ion_text`|11s|

In addition, this PR fixed few typo, modified unit test. I also left comments to highlight some changes.

## Test
Unit test, 204/204 passed

## Example
**Command**
```
(venv) ion-python % python amazon/ionbenchmark/ion_benchmark_cli.py write --api simple_ion --format ion_binary --format ion_text test_unit_int
```
**Configuration Options**
```
[('simple_ion', 'ion_text'), ('simple_ion', 'ion_binary')]
```
**Result**
<img width="732" alt="Screenshot 2023-02-02 at 3 47 53 PM" src="https://user-images.githubusercontent.com/67451029/216476647-166fc711-5bac-45a2-bb78-0143a9d18797.png">





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
