### PR TITLE
Adds support for flexible symbol buffer threshold.

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -1468,11 +1468,11 @@ PyObject* ionc_read(PyObject* self, PyObject *args, PyObject *kwds) {
     iENTER;
     PyObject *py_file = NULL; // TextIOWrapper
     PyObject *emit_bare_values;
-    PyObject *symbol_buffer_threshold;
+    PyObject *text_buffer_size_limit;
     ionc_read_Iterator *iterator = NULL;
-    static char *kwlist[] = {"file", "emit_bare_values", "symbol_buffer_threshold", NULL};
+    static char *kwlist[] = {"file", "emit_bare_values", "text_buffer_size_limit", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kwds, IONC_READ_ARGS_FORMAT, kwlist, &py_file,
-                                        &emit_bare_values, &symbol_buffer_threshold)) {
+                                        &emit_bare_values, &text_buffer_size_limit)) {
         FAILWITH(IERR_INVALID_ARG);
     }
 
@@ -1492,9 +1492,10 @@ PyObject* ionc_read(PyObject* self, PyObject *args, PyObject *kwds) {
     memset(&iterator->reader, 0, sizeof(iterator->reader));
     memset(&iterator->_reader_options, 0, sizeof(iterator->_reader_options));
     iterator->_reader_options.decimal_context = &dec_context;
-    if (symbol_buffer_threshold != Py_None) {
-        int symbol_threshold = PyLong_AsLong(symbol_buffer_threshold);
+    if (text_buffer_size_limit != Py_None) {
+        int symbol_threshold = PyLong_AsLong(text_buffer_size_limit);
         iterator->_reader_options.symbol_threshold = symbol_threshold;
+        Py_XDECREF(text_buffer_size_limit);
     }
 
     IONCHECK(ion_reader_open_stream(

--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -29,7 +29,7 @@ static char _err_msg[ERR_MSG_MAX_LEN];
 #define _FAILWITHMSG(x, msg) { err = x; snprintf(_err_msg, ERR_MSG_MAX_LEN, msg); goto fail; }
 
 #define IONC_BYTES_FORMAT "y#"
-#define IONC_READ_ARGS_FORMAT "OO"
+#define IONC_READ_ARGS_FORMAT "OOO"
 
 static PyObject* _math_module;
 
@@ -1468,9 +1468,11 @@ PyObject* ionc_read(PyObject* self, PyObject *args, PyObject *kwds) {
     iENTER;
     PyObject *py_file = NULL; // TextIOWrapper
     PyObject *emit_bare_values;
+    PyObject *symbol_buffer_threshold;
     ionc_read_Iterator *iterator = NULL;
-    static char *kwlist[] = {"file", "emit_bare_values", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, IONC_READ_ARGS_FORMAT, kwlist, &py_file, &emit_bare_values)) {
+    static char *kwlist[] = {"file", "emit_bare_values", "symbol_buffer_threshold", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, IONC_READ_ARGS_FORMAT, kwlist, &py_file,
+                                        &emit_bare_values, &symbol_buffer_threshold)) {
         FAILWITH(IERR_INVALID_ARG);
     }
 
@@ -1490,6 +1492,10 @@ PyObject* ionc_read(PyObject* self, PyObject *args, PyObject *kwds) {
     memset(&iterator->reader, 0, sizeof(iterator->reader));
     memset(&iterator->_reader_options, 0, sizeof(iterator->_reader_options));
     iterator->_reader_options.decimal_context = &dec_context;
+    if (symbol_buffer_threshold != Py_None) {
+        int symbol_threshold = PyLong_AsLong(symbol_buffer_threshold);
+        iterator->_reader_options.symbol_threshold = symbol_threshold;
+    }
 
     IONCHECK(ion_reader_open_stream(
         &iterator->reader,

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -443,7 +443,8 @@ def _load(out, reader, end_type=IonEventType.STREAM_END, in_struct=False):
 
 
 def loads(ion_str, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
-          parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=True, **kw):
+          parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=True,
+          symbol_buffer_threshold=None, **kw):
     """Deserialize ``ion_str``, which is a string representation of an Ion object, to a Python object using the
     conversion table used by load (above).
 
@@ -482,7 +483,8 @@ def loads(ion_str, catalog=None, single_value=True, encoding='utf-8', cls=None, 
 
     return load(ion_buffer, catalog=catalog, single_value=single_value, encoding=encoding, cls=cls,
                 object_hook=object_hook, parse_float=parse_float, parse_int=parse_int, parse_constant=parse_constant,
-                object_pairs_hook=object_pairs_hook, use_decimal=use_decimal, parse_eagerly=parse_eagerly)
+                object_pairs_hook=object_pairs_hook, use_decimal=use_decimal, parse_eagerly=parse_eagerly,
+                symbol_buffer_threshold=symbol_buffer_threshold)
 
 
 def dump_extension(obj, fp, binary=True, sequence_as_stream=False, tuple_as_sexp=False, omit_version_marker=False):

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -457,7 +457,9 @@ def loads(ion_str, catalog=None, single_value=True, encoding='utf-8', cls=None, 
             ``sequence_as_stream=True``, it must be loaded using ``single_value=False``. Default: True.
         parse_eagerly: (Optional[True|False]) Used in conjunction with ``single_value=False`` to return the result as list
             or an iterator
-        text_buffer_size_limit: The size maximum size allowed for text, 512 bytes is the default
+        text_buffer_size_limit: The size maximum size allowed for text, 512 bytes is the default. This option only works
+            when C extension is enabled (and it is enabled by default). Raising text buffer limit is required for text
+            values that exceed 512 bytes. Refer to https://github.com/amazon-ion/ion-python/pull/238 for details
         encoding: NOT IMPLEMENTED
         cls: NOT IMPLEMENTED
         object_hook: NOT IMPLEMENTED
@@ -507,7 +509,9 @@ def load_extension(fp, single_value=True, parse_eagerly=True, text_buffer_size_l
             ``sequence_as_stream=True``, it must be loaded using ``single_value=False``. Default: True.
         parse_eagerly: (Optional[True|False]) Used in conjunction with ``single_value=False`` to return the result as list
             or an iterator
-        text_buffer_size_limit: The size maximum size allowed for text, 512 bytes is the default
+        text_buffer_size_limit: The size maximum size allowed for text, 512 bytes is the default. This option only works
+            when C extension is enabled (and it is enabled by default). Raising text buffer limit is required for text
+            values that exceed 512 bytes. Refer to https://github.com/amazon-ion/ion-python/pull/238 for details
     """
     iterator = ionc.ionc_read(fp, emit_bare_values=False, text_buffer_size_limit=text_buffer_size_limit)
     if single_value:

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -457,9 +457,9 @@ def loads(ion_str, catalog=None, single_value=True, encoding='utf-8', cls=None, 
             ``sequence_as_stream=True``, it must be loaded using ``single_value=False``. Default: True.
         parse_eagerly: (Optional[True|False]) Used in conjunction with ``single_value=False`` to return the result as list
             or an iterator
-        text_buffer_size_limit: The size maximum size allowed for text, 512 bytes is the default. This option only works
-            when C extension is enabled (and it is enabled by default). Raising text buffer limit is required for text
-            values that exceed 512 bytes. Refer to https://github.com/amazon-ion/ion-python/pull/238 for details
+        text_buffer_size_limit (int): The maximum byte size allowed for text values when the C extension is enabled
+            (default: 512 bytes). This option only has an effect when the C extension is enabled (and it is enabled by
+            default). When the C extension is disabled, there is no limit on the size of text values.
         encoding: NOT IMPLEMENTED
         cls: NOT IMPLEMENTED
         object_hook: NOT IMPLEMENTED
@@ -509,9 +509,9 @@ def load_extension(fp, single_value=True, parse_eagerly=True, text_buffer_size_l
             ``sequence_as_stream=True``, it must be loaded using ``single_value=False``. Default: True.
         parse_eagerly: (Optional[True|False]) Used in conjunction with ``single_value=False`` to return the result as list
             or an iterator
-        text_buffer_size_limit: The size maximum size allowed for text, 512 bytes is the default. This option only works
-            when C extension is enabled (and it is enabled by default). Raising text buffer limit is required for text
-            values that exceed 512 bytes. Refer to https://github.com/amazon-ion/ion-python/pull/238 for details
+        text_buffer_size_limit (int): The maximum byte size allowed for text values when the C extension is enabled
+            (default: 512 bytes). This option only has an effect when the C extension is enabled (and it is enabled by
+            default). When the C extension is disabled, there is no limit on the size of text values.
     """
     iterator = ionc.ionc_read(fp, emit_bare_values=False, text_buffer_size_limit=text_buffer_size_limit)
     if single_value:

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -39,17 +39,19 @@ try:
 except ModuleNotFoundError:
     c_ext = False
 
-
 _ION_CONTAINER_END_EVENT = IonEvent(IonEventType.CONTAINER_END)
 _IVM = b'\xe0\x01\x00\xea'
 _TEXT_TYPES = (TextIOBase, io.StringIO)
 
 
 def dump_python(obj, fp, imports=None, binary=True, sequence_as_stream=False, skipkeys=False, ensure_ascii=True,
-         check_circular=True, allow_nan=True, cls=None, indent=None, separators=None, encoding='utf-8', default=None,
-         use_decimal=True, namedtuple_as_object=True, tuple_as_array=True, bigint_as_string=False, sort_keys=False,
-         item_sort_key=None, for_json=None, ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False,
-         tuple_as_sexp=False, omit_version_marker=False, **kw):
+                check_circular=True, allow_nan=True, cls=None, indent=None, separators=None, encoding='utf-8',
+                default=None,
+                use_decimal=True, namedtuple_as_object=True, tuple_as_array=True, bigint_as_string=False,
+                sort_keys=False,
+                item_sort_key=None, for_json=None, ignore_nan=False, int_as_string_bitcount=None,
+                iterable_as_array=False,
+                tuple_as_sexp=False, omit_version_marker=False, **kw):
     """Serialize ``obj`` as an Ion-formatted stream to ``fp`` (a file-like object), using the following conversion
     table::
         +-------------------+-------------------+
@@ -214,10 +216,10 @@ def _dump(obj, writer, from_type, field=None, in_struct=False, depth=0):
         writer.send(event)
         if ion_type is IonType.STRUCT:
             for field, val in iter(obj.items()):
-                _dump(val, writer, from_type, field, in_struct=True, depth=depth+1)
+                _dump(val, writer, from_type, field, in_struct=True, depth=depth + 1)
         else:
             for elem in obj:
-                _dump(elem, writer, from_type, depth=depth+1)
+                _dump(elem, writer, from_type, depth=depth + 1)
         event = _ION_CONTAINER_END_EVENT
     else:
         # obj is a scalar value
@@ -228,7 +230,8 @@ def _dump(obj, writer, from_type, field=None, in_struct=False, depth=0):
     writer.send(event)
 
 
-def dumps(obj, imports=None, binary=True, sequence_as_stream=False, skipkeys=False, ensure_ascii=True, check_circular=True,
+def dumps(obj, imports=None, binary=True, sequence_as_stream=False, skipkeys=False, ensure_ascii=True,
+          check_circular=True,
           allow_nan=True, cls=None, indent=None, separators=None, encoding='utf-8', default=None, use_decimal=True,
           namedtuple_as_object=True, tuple_as_array=True, bigint_as_string=False, sort_keys=False, item_sort_key=None,
           for_json=None, ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False, tuple_as_sexp=False,
@@ -293,7 +296,8 @@ def dumps(obj, imports=None, binary=True, sequence_as_stream=False, skipkeys=Fal
 
 
 def load_python(fp, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
-        parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=True, **kw):
+                parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=True,
+                **kw):
     """Deserialize ``fp`` (a file-like object), which contains a text or binary Ion stream, to a Python object using the
     following conversion table::
         +-------------------+-------------------+
@@ -397,6 +401,7 @@ _FROM_ION_TYPE = [
     IonPyDict
 ]
 
+
 def _load_iteratively(reader, end_type=IonEventType.STREAM_END):
     event = reader.send(NEXT_EVENT)
     while event.event_type is not end_type:
@@ -413,8 +418,8 @@ def _load_iteratively(reader, end_type=IonEventType.STREAM_END):
             yield scalar
         event = reader.send(NEXT_EVENT)
 
-def _load(out, reader, end_type=IonEventType.STREAM_END, in_struct=False):
 
+def _load(out, reader, end_type=IonEventType.STREAM_END, in_struct=False):
     def add(obj):
         if in_struct:
             out.add_item(event.field_name.text, obj)
@@ -489,8 +494,19 @@ def dump_extension(obj, fp, binary=True, sequence_as_stream=False, tuple_as_sexp
     fp.write(res)
 
 
-def load_extension(fp, single_value=True, parse_eagerly=True):
-    iterator = ionc.ionc_read(fp, emit_bare_values=False)
+def load_extension(fp, single_value=True, parse_eagerly=True, symbol_buffer_threshold=512):
+    """
+    Args:
+        fp (str): A string representation of Ion data.
+        single_value (Optional[True|False]): When True, the data in ``ion_str`` is interpreted as a single Ion value,
+            and will be returned without an enclosing container. If True and there are multiple top-level values in
+            the Ion stream, IonException will be raised. NOTE: this means that when data is dumped using
+            ``sequence_as_stream=True``, it must be loaded using ``single_value=False``. Default: True.
+        parse_eagerly: (Optional[True|False]) Used in conjunction with ``single_value=False`` to return the result as list
+            or an iterator
+        symbol_buffer_threshold: The size maximum size allowed for symbols, 512 bytes is the default
+    """
+    iterator = ionc.ionc_read(fp, emit_bare_values=False, symbol_buffer_threshold=symbol_buffer_threshold)
     if single_value:
         try:
             value = next(iterator)
@@ -517,21 +533,23 @@ def dump(obj, fp, imports=None, binary=True, sequence_as_stream=False, skipkeys=
                               tuple_as_sexp=tuple_as_sexp, omit_version_marker=omit_version_marker)
     else:
         return dump_python(obj, fp, imports=imports, binary=binary, sequence_as_stream=sequence_as_stream,
-                         skipkeys=skipkeys, ensure_ascii=ensure_ascii,check_circular=check_circular,
-                         allow_nan=allow_nan, cls=cls, indent=indent, separators=separators, encoding=encoding,
-                         default=default, use_decimal=use_decimal, namedtuple_as_object=namedtuple_as_object,
-                         tuple_as_array=tuple_as_array, bigint_as_string=bigint_as_string, sort_keys=sort_keys,
-                         item_sort_key=item_sort_key, for_json=for_json, ignore_nan=ignore_nan,
-                         int_as_string_bitcount=int_as_string_bitcount, iterable_as_array=iterable_as_array,
-                         tuple_as_sexp=tuple_as_sexp, omit_version_marker=omit_version_marker, **kw)
+                           skipkeys=skipkeys, ensure_ascii=ensure_ascii, check_circular=check_circular,
+                           allow_nan=allow_nan, cls=cls, indent=indent, separators=separators, encoding=encoding,
+                           default=default, use_decimal=use_decimal, namedtuple_as_object=namedtuple_as_object,
+                           tuple_as_array=tuple_as_array, bigint_as_string=bigint_as_string, sort_keys=sort_keys,
+                           item_sort_key=item_sort_key, for_json=for_json, ignore_nan=ignore_nan,
+                           int_as_string_bitcount=int_as_string_bitcount, iterable_as_array=iterable_as_array,
+                           tuple_as_sexp=tuple_as_sexp, omit_version_marker=omit_version_marker, **kw)
 
 
 def load(fp, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
-         parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=True, **kw):
+         parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=True,
+         symbol_buffer_threshold=512, **kw):
     if c_ext and catalog is None:
-        return load_extension(fp, parse_eagerly=parse_eagerly, single_value=single_value)
+        return load_extension(fp, parse_eagerly=parse_eagerly, single_value=single_value,
+                              symbol_buffer_threshold=symbol_buffer_threshold)
     else:
         return load_python(fp, catalog=catalog, single_value=single_value, encoding=encoding, cls=cls,
-                         object_hook=object_hook, parse_float=parse_float, parse_int=parse_int,
-                         parse_constant=parse_constant, object_pairs_hook=object_pairs_hook,
-                         use_decimal=use_decimal, parse_eagerly=parse_eagerly, **kw)
+                           object_hook=object_hook, parse_float=parse_float, parse_int=parse_int,
+                           parse_constant=parse_constant, object_pairs_hook=object_pairs_hook,
+                           use_decimal=use_decimal, parse_eagerly=parse_eagerly, symbol_buffer_threshold=512, **kw)

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -494,7 +494,7 @@ def dump_extension(obj, fp, binary=True, sequence_as_stream=False, tuple_as_sexp
     fp.write(res)
 
 
-def load_extension(fp, single_value=True, parse_eagerly=True, symbol_buffer_threshold=512):
+def load_extension(fp, single_value=True, parse_eagerly=True, symbol_buffer_threshold=None):
     """
     Args:
         fp (str): A string representation of Ion data.
@@ -544,7 +544,7 @@ def dump(obj, fp, imports=None, binary=True, sequence_as_stream=False, skipkeys=
 
 def load(fp, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
          parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=True,
-         symbol_buffer_threshold=512, **kw):
+         symbol_buffer_threshold=None, **kw):
     if c_ext and catalog is None:
         return load_extension(fp, parse_eagerly=parse_eagerly, single_value=single_value,
                               symbol_buffer_threshold=symbol_buffer_threshold)
@@ -552,4 +552,4 @@ def load(fp, catalog=None, single_value=True, encoding='utf-8', cls=None, object
         return load_python(fp, catalog=catalog, single_value=single_value, encoding=encoding, cls=cls,
                            object_hook=object_hook, parse_float=parse_float, parse_int=parse_int,
                            parse_constant=parse_constant, object_pairs_hook=object_pairs_hook,
-                           use_decimal=use_decimal, parse_eagerly=parse_eagerly, symbol_buffer_threshold=512, **kw)
+                           use_decimal=use_decimal, parse_eagerly=parse_eagerly, **kw)

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -444,7 +444,7 @@ def _load(out, reader, end_type=IonEventType.STREAM_END, in_struct=False):
 
 def loads(ion_str, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
           parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=True,
-          symbol_buffer_threshold=None, **kw):
+          text_buffer_size_limit=None, **kw):
     """Deserialize ``ion_str``, which is a string representation of an Ion object, to a Python object using the
     conversion table used by load (above).
 
@@ -457,6 +457,7 @@ def loads(ion_str, catalog=None, single_value=True, encoding='utf-8', cls=None, 
             ``sequence_as_stream=True``, it must be loaded using ``single_value=False``. Default: True.
         parse_eagerly: (Optional[True|False]) Used in conjunction with ``single_value=False`` to return the result as list
             or an iterator
+        text_buffer_size_limit: The size maximum size allowed for text, 512 bytes is the default
         encoding: NOT IMPLEMENTED
         cls: NOT IMPLEMENTED
         object_hook: NOT IMPLEMENTED
@@ -484,7 +485,7 @@ def loads(ion_str, catalog=None, single_value=True, encoding='utf-8', cls=None, 
     return load(ion_buffer, catalog=catalog, single_value=single_value, encoding=encoding, cls=cls,
                 object_hook=object_hook, parse_float=parse_float, parse_int=parse_int, parse_constant=parse_constant,
                 object_pairs_hook=object_pairs_hook, use_decimal=use_decimal, parse_eagerly=parse_eagerly,
-                symbol_buffer_threshold=symbol_buffer_threshold)
+                text_buffer_size_limit=text_buffer_size_limit)
 
 
 def dump_extension(obj, fp, binary=True, sequence_as_stream=False, tuple_as_sexp=False, omit_version_marker=False):
@@ -496,7 +497,7 @@ def dump_extension(obj, fp, binary=True, sequence_as_stream=False, tuple_as_sexp
     fp.write(res)
 
 
-def load_extension(fp, single_value=True, parse_eagerly=True, symbol_buffer_threshold=None):
+def load_extension(fp, single_value=True, parse_eagerly=True, text_buffer_size_limit=None):
     """
     Args:
         fp (str): A string representation of Ion data.
@@ -506,9 +507,9 @@ def load_extension(fp, single_value=True, parse_eagerly=True, symbol_buffer_thre
             ``sequence_as_stream=True``, it must be loaded using ``single_value=False``. Default: True.
         parse_eagerly: (Optional[True|False]) Used in conjunction with ``single_value=False`` to return the result as list
             or an iterator
-        symbol_buffer_threshold: The size maximum size allowed for symbols, 512 bytes is the default
+        text_buffer_size_limit: The size maximum size allowed for text, 512 bytes is the default
     """
-    iterator = ionc.ionc_read(fp, emit_bare_values=False, symbol_buffer_threshold=symbol_buffer_threshold)
+    iterator = ionc.ionc_read(fp, emit_bare_values=False, text_buffer_size_limit=text_buffer_size_limit)
     if single_value:
         try:
             value = next(iterator)
@@ -546,10 +547,10 @@ def dump(obj, fp, imports=None, binary=True, sequence_as_stream=False, skipkeys=
 
 def load(fp, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
          parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=True,
-         symbol_buffer_threshold=None, **kw):
+         text_buffer_size_limit=None, **kw):
     if c_ext and catalog is None:
         return load_extension(fp, parse_eagerly=parse_eagerly, single_value=single_value,
-                              symbol_buffer_threshold=symbol_buffer_threshold)
+                              text_buffer_size_limit=text_buffer_size_limit)
     else:
         return load_python(fp, catalog=catalog, single_value=single_value, encoding=encoding, cls=cls,
                            object_hook=object_hook, parse_float=parse_float, parse_int=parse_int,

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -713,3 +713,22 @@ def test_loads_unicode_utf8_conversion():
     # Loads API should convert it to UTF-8 without illegal bytes number read exception.
     loads(data, parse_eagerly=True)
 
+
+# See issue https://github.com/amazon-ion/ion-python/issues/232
+def test_loads_large_string():
+    data = "a"*100000
+
+    # Without symbol_buffer_threshold setup, it should fail due to BUFFER_TOO_SMALL
+    try:
+        loads(data)
+    except Exception:
+        pass
+    else:
+        assert False
+
+    # With symbol_buffer_threshold setup, it should have enough buffer size to handle "a"*100000
+    try:
+        loads(data, symbol_buffer_threshold=200000)
+    except Exception:
+        assert False
+

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -717,7 +717,7 @@ def test_loads_unicode_utf8_conversion():
 # See issue https://github.com/amazon-ion/ion-python/issues/232
 def test_loads_large_string():
     # This function only tests c extension
-    if c_ext:
+    if not c_ext:
         return
 
     data = "a"*100000

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -716,6 +716,10 @@ def test_loads_unicode_utf8_conversion():
 
 # See issue https://github.com/amazon-ion/ion-python/issues/232
 def test_loads_large_string():
+    # This function only tests c extension
+    if c_ext:
+        return
+
     data = "a"*100000
 
     # Without symbol_buffer_threshold setup, it should fail due to BUFFER_TOO_SMALL

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -732,7 +732,7 @@ def test_loads_large_string():
 
     # With symbol_buffer_threshold setup, it should have enough buffer size to handle "a"*100000
     try:
-        loads(data, symbol_buffer_threshold=200000)
+        loads(data, text_buffer_size_limit=200000)
     except Exception:
         assert False
 


### PR DESCRIPTION
### Description
This PR fixed https://github.com/amazon-ion/ion-python/issues/232

### Root
In short, ion-c's [symbol_threshold](https://github.com/amazon-ion/ion-c/blob/master/ionc/include/ionc/ion_reader.h#L101-L104) limited the size of the string we are able to read.

The exception is threw by [this line](https://github.com/amazon-ion/ion-c/blob/master/ionc/ion_reader_text.c#L1800). The reason that `eos_encountered` is false is because ion_scanner’s value buffer contains limited buffer, which is initialized [here](https://github.com/amazon-ion/ion-c/blob/master/ionc/ion_scanner.c#L93). You will see that value_buffer_length is assigned as symbol_threshold (512 bytes by default). 

### Solution
So change the [option.symbol_threshold](https://github.com/amazon-ion/ion-c/blob/master/ionc/include/ionc/ion_reader.h#L101-L104) to a bigger number (E.g., file size) solves issue. 

However, A fixed buffer of specific size is preallocated to hold symbols encountered by the reader. If users only want to read a 2GB file, there is no need to allocate a 2GB buffer just to hold symbols. 

So, This PR adds an option `symbol_buffer_threshold` to allow users specify desired buffer size for their use case and it's 512 by default.

### Example
For example in https://github.com/amazon-ion/ion-python/issues/232
#### File (test.ion)
```
{attribute:"aaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdasaaaaaaaaasdfasdfsfasdfadsfdsfdas"}
```
#### Code
```.py
from amazon.ion import simpleion

with open("test.ion", "br") as fp:
     print("started for 80k threshold")
     simpleion.load(fp, single_value=False, symbol_buffer_threshold=80000)
     print("finished for 80k threshold")

with open("test.ion", "br") as fp:
     print("started for 512 threshold")
     print(simpleion.load(fp, single_value=False))
     print("finished for 512 threshold")
```
#### Result
```.c
started for 80k threshold
finished for 80k threshold
started for 512 threshold
Traceback (most recent call last):
  File "/Users/cheqianh/Desktop/ion-python/amazon/ion/test2.py", line 24, in <module>
    print(simpleion.load(fp, single_value=False))
  File "/Users/cheqianh/Desktop/ion-python/amazon/ion/simpleion.py", line 549, in load
    return load_extension(fp, parse_eagerly=parse_eagerly, single_value=single_value,
  File "/Users/cheqianh/Desktop/ion-python/amazon/ion/simpleion.py", line 522, in load_extension
    return list(iterator)
amazon.ion.exceptions.IonException: IERR_BUFFER_TOO_SMALL
```
So the first execution with 80000 bytes buffer threshold works, if we didn't specify threshold, it will be set to 512 and failed the large symbol case.

### Test
Passed all tests, plus specific sample file with large string. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
