### PR TITLE
Updates release versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8' ]
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up python


### PR DESCRIPTION
We dropped 3.6 and pypy-3.6 support earlier, remove them from release script too.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
