### PR TITLE
Adds JSON/CBOR support and an Io-type option

### DIFF
--- a/amazon/ionbenchmark/API.py
+++ b/amazon/ionbenchmark/API.py
@@ -4,6 +4,6 @@ from enum import Enum
 # Serialization/deserialization APIs to benchmark.
 class API(Enum):
     """Enumeration of the APIs."""
-    SIMPLE_ION = 'simple_ion'
-    EVENT = 'event'
-    DEFAULT = 'simple_ion'
+    LOAD_DUMP = 'load_dump'
+    STREAMING = 'streaming'
+    DEFAULT = 'load_dump'

--- a/amazon/ionbenchmark/Command.py
+++ b/amazon/ionbenchmark/Command.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class Command(Enum):
+    """Enumeration of the Command."""
+    READ = 'read'
+    WRITE = 'write'

--- a/amazon/ionbenchmark/Format.py
+++ b/amazon/ionbenchmark/Format.py
@@ -1,8 +1,39 @@
 from enum import Enum
 
 
+def format_is_ion(format_option):
+    return (format_option == Format.ION_BINARY.value) or (format_option == Format.ION_TEXT.value)
+
+
+def format_is_json(format_option):
+    return (format_option == Format.JSON.value) or (format_option == Format.SIMPLEJSON.value) \
+           or (format_option == Format.UJSON.value) or (format_option == Format.RAPIDJSON.value) or \
+           (format_option == Format.ORJSON.value)
+
+
+def format_is_cbor(format_option):
+    return (format_option == Format.CBOR.value) or (format_option == Format.CBOR2.value)
+
+
+def format_is_binary(format_option):
+    return format_is_cbor(format_option) or (format_option == Format.ION_BINARY.value) \
+           or (format_option == Format.ORJSON.value)
+
+
+def rewrite_file_to_format(file, format_option):
+    return file
+
+
 class Format(Enum):
     """Enumeration of the formats."""
     ION_TEXT = 'ion_text'
     ION_BINARY = 'ion_binary'
+    JSON = 'json'
+    SIMPLEJSON = 'simplejson'
+    UJSON = 'ujson'
+    RAPIDJSON = 'rapidjson'
+    ORJSON = 'orjson'
+    CBOR = 'cbor'
+    CBOR2 = 'cbor2'
     DEFAULT = 'ion_binary'
+

--- a/amazon/ionbenchmark/Format.py
+++ b/amazon/ionbenchmark/Format.py
@@ -7,8 +7,7 @@ def format_is_ion(format_option):
 
 def format_is_json(format_option):
     return (format_option == Format.JSON.value) or (format_option == Format.SIMPLEJSON.value) \
-           or (format_option == Format.UJSON.value) or (format_option == Format.RAPIDJSON.value) or \
-           (format_option == Format.ORJSON.value)
+           or (format_option == Format.UJSON.value) or (format_option == Format.RAPIDJSON.value)
 
 
 def format_is_cbor(format_option):
@@ -16,8 +15,7 @@ def format_is_cbor(format_option):
 
 
 def format_is_binary(format_option):
-    return format_is_cbor(format_option) or (format_option == Format.ION_BINARY.value) \
-           or (format_option == Format.ORJSON.value)
+    return format_is_cbor(format_option) or (format_option == Format.ION_BINARY.value)
 
 
 def rewrite_file_to_format(file, format_option):
@@ -32,7 +30,6 @@ class Format(Enum):
     SIMPLEJSON = 'simplejson'
     UJSON = 'ujson'
     RAPIDJSON = 'rapidjson'
-    ORJSON = 'orjson'
     CBOR = 'cbor'
     CBOR2 = 'cbor2'
     DEFAULT = 'ion_binary'

--- a/amazon/ionbenchmark/Io_type.py
+++ b/amazon/ionbenchmark/Io_type.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class Io_type(Enum):
+    """Enumeration of the IO types."""
+    FILE = 'file'
+    BUFFER = 'buffer'
+    DEFAULT = 'file'

--- a/amazon/ionbenchmark/ion_benchmark_cli.py
+++ b/amazon/ionbenchmark/ion_benchmark_cli.py
@@ -46,8 +46,9 @@ Options:
      -c --c-extension <bool>            If the C extension is enabled, note that it only applies to simpleIon module.
                                         [default: True]
 
-     -f --format <format>               Format to benchmark, from the set (ion_binary | ion_text). May be specified
-                                        multiple times to compare different formats. [default: ion_binary]
+     -f --format <format>               Format to benchmark, from the set (ion_binary | ion_text | json | simplejson |
+                                        ujson | rapidjson | orjson | cbor | cbor2). May be specified multiple times to
+                                        compare different formats. [default: ion_binary]
 
      -p --profile                       (NOT SUPPORTED YET) Initiates a single iteration that repeats indefinitely until
                                         terminated, allowing users to attach profiling tools. If this option is

--- a/install.py
+++ b/install.py
@@ -89,6 +89,9 @@ def _download_ionc():
 
         os.chdir(_CURRENT_ION_C_DIR)
 
+        # TODO Use ion-c 1.1.0 for now - https://github.com/amazon-ion/ion-python/issues/249
+        check_call(['git', 'reset', '--hard', 'v1.1.0'])
+
         # Initialize submodule.
         check_call(['git', 'submodule', 'update', '--init'])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,11 @@ virtualenv==20.4.7
 setuptools<=60.5.0
 docopt==0.6.2
 tabulate==0.9.0
-simplejson
+simplejson~=3.18.3
+pip~=23.0
+six~=1.16.0
+cbor~=1.0.0
+orjson~=3.8.6
+cbor2~=5.4.6
+python-rapidjson~=1.9
+ujson~=5.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ virtualenv==20.4.7
 setuptools<=60.5.0
 docopt==0.6.2
 tabulate==0.9.0
+simplejson

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ simplejson~=3.18.3
 pip~=23.0
 six~=1.16.0
 cbor~=1.0.0
-orjson~=3.8.6
 cbor2~=5.4.6
 python-rapidjson~=1.9
 ujson~=5.7.0

--- a/tests/benchmark_sample_data/cbor/sample
+++ b/tests/benchmark_sample_data/cbor/sample
@@ -1,0 +1,1 @@
+sthis is a test file

--- a/tests/benchmark_sample_data/json/object.json
+++ b/tests/benchmark_sample_data/json/object.json
@@ -1,0 +1,1 @@
+{"name":"John", "age":30, "car":null}

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -191,9 +191,9 @@ def test_read_json_format(f):
 
 
 @parametrize(
-    *tuple((f.value for f in Format.Format if Format.format_is_json(f.value)))
+    *tuple((f.value for f in Format.Format if Format.format_is_cbor(f.value)))
 )
-def test_write_json_format(f):
+def test_write_cbor_format(f):
     table = execution_with_command(['write', generate_test_path('integers.ion'), '--format', f'{f}'])
     assert gather_all_options_in_list(table) == sorted([('simple_ion', f'{f}', 'file')])
 

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -1,13 +1,16 @@
+import json
 import time
 from itertools import chain
 from os.path import abspath, join, dirname
 
+import cbor2
 from docopt import docopt
 
 from amazon.ion import simpleion
 from amazon.ionbenchmark import ion_benchmark_cli, Format, Io_type
-from amazon.ionbenchmark.ion_benchmark_cli import generate_simpleion_read_test_code, \
-    generate_simpleion_write_test_code, ion_python_benchmark_cli
+from amazon.ionbenchmark.Format import format_is_ion, format_is_cbor, format_is_json
+from amazon.ionbenchmark.ion_benchmark_cli import generate_read_test_code, \
+    generate_write_test_code, ion_python_benchmark_cli
 from amazon.ionbenchmark.util import str_to_bool, TOOL_VERSION
 from tests import parametrize
 from tests.test_simpleion import generate_scalars_text
@@ -45,12 +48,45 @@ def generate_test_path(p):
     generate_test_path('integers.ion')
 )
 def test_generate_simpleion_read_test_code(path):
-    actual = generate_simpleion_read_test_code(path, memory_profiling=False, single_value=False,
-                                               emit_bare_values=False, io_type='buffer')
+    actual = generate_read_test_code(path, memory_profiling=False, single_value=False,
+                                     format_option=Format.Format.ION_TEXT.value, emit_bare_values=False,
+                                     io_type=Io_type.Io_type.FILE, binary=False)
 
     # make sure we generated the desired load function
     with open(path) as fp:
-        expect = simpleion.load(fp, single_value=False, parse_eagerly=True)
+        expect = simpleion.load(fp, single_value=False, emit_bare_values=False, parse_eagerly=True)
+
+    # make sure the return values are same
+    assert actual() == expect
+
+
+@parametrize(
+    generate_test_path('integers.ion')
+)
+def test_generate_json_read_test_code(path):
+    actual = generate_read_test_code(path, memory_profiling=False, single_value=False,
+                                     format_option=Format.Format.JSON.value, emit_bare_values=False,
+                                     io_type=Io_type.Io_type.FILE, binary=False)
+
+    # make sure we generated the desired load function
+    with open(path) as fp:
+        expect = json.load(fp)
+
+    # make sure the return values are same
+    assert actual() == expect
+
+
+@parametrize(
+    generate_test_path('integers.ion')
+)
+def test_generate_cbor_read_test_code(path):
+    actual = generate_read_test_code(path, memory_profiling=False, single_value=False,
+                                     format_option=Format.Format.CBOR2.value, emit_bare_values=False,
+                                     io_type=Io_type.Io_type.FILE, binary=False)
+
+    # make sure we generated the desired load function
+    with open(path) as fp:
+        expect = cbor2.load(fp)
 
     # make sure the return values are same
     assert actual() == expect
@@ -62,10 +98,43 @@ def test_generate_simpleion_read_test_code(path):
     ))
 )
 def test_generate_simpleion_write_test_code(obj):
-    actual = generate_simpleion_write_test_code(obj, memory_profiling=False, binary=False, io_type='buffer')
+    actual = generate_write_test_code(obj, format_option=Format.Format.ION_TEXT.value, memory_profiling=False,
+                                      binary=False, io_type=Io_type.Io_type.BUFFER.value)
 
     # make sure we generated the desired dumps function
     expect = simpleion.dumps(obj, binary=False)
+
+    # make sure the return values are same
+    assert actual() == expect
+
+
+@parametrize(
+    generate_test_path('./json/object.json'),
+)
+def test_generate_json_write_test_code(file):
+    with open(file) as fp:
+        obj = json.load(fp)
+    actual = generate_write_test_code(obj, format_option=Format.Format.JSON.value, memory_profiling=False, binary=False,
+                                      io_type=Io_type.Io_type.BUFFER.value)
+
+    # make sure we generated the desired dumps function
+    expect = json.dumps(obj)
+
+    # make sure the return values are same
+    assert actual() == expect
+
+
+@parametrize(
+    generate_test_path('./cbor/sample')
+)
+def test_generate_cbor_write_test_code(file):
+    with open(file, 'br') as fp:
+        obj = cbor2.load(fp)
+    actual = generate_write_test_code(obj, format_option=Format.Format.CBOR2.value, memory_profiling=False,
+                                      binary=False, io_type=Io_type.Io_type.BUFFER.value)
+
+    # make sure we generated the desired dumps function
+    expect = cbor2.dumps(obj)
 
     # make sure the return values are same
     assert actual() == expect
@@ -135,43 +204,53 @@ def gather_all_options_in_list(table):
 
 
 def test_read_multi_api(file=generate_test_path('integers.ion')):
-    table = execution_with_command(['read', file, '--api', 'simple_ion', '--api', 'event'])
-    assert gather_all_options_in_list(table) == sorted([('event', 'ion_binary', 'file'), ('simple_ion', 'ion_binary', 'file')])
+    table = execution_with_command(['read', file, '--api', 'load_dump', '--api', 'streaming'])
+    assert gather_all_options_in_list(table) == sorted(
+        [('streaming', 'ion_binary', 'file'), ('load_dump', 'ion_binary', 'file')])
 
 
 def test_write_multi_api(file=generate_test_path('integers.ion')):
-    table = execution_with_command(['write', file, '--api', 'simple_ion', '--api', 'event'])
-    assert gather_all_options_in_list(table) == sorted([('event', 'ion_binary', 'file'), ('simple_ion', 'ion_binary', 'file')])
+    table = execution_with_command(['write', file, '--api', 'load_dump', '--api', 'streaming'])
+    assert gather_all_options_in_list(table) == sorted(
+        [('streaming', 'ion_binary', 'file'), ('load_dump', 'ion_binary', 'file')])
 
 
 def test_read_multi_duplicated_api(file=generate_test_path('integers.ion')):
-    table = execution_with_command(['read', file, '--api', 'simple_ion', '--api', 'event', '--api', 'event'])
-    assert gather_all_options_in_list(table) == sorted([('event', 'ion_binary', 'file'), ('simple_ion', 'ion_binary', 'file')])
+    table = execution_with_command(['read', file, '--api', 'load_dump', '--api', 'streaming', '--api', 'streaming'])
+    assert gather_all_options_in_list(table) == sorted(
+        [('streaming', 'ion_binary', 'file'), ('load_dump', 'ion_binary', 'file')])
 
 
 def test_write_multi_duplicated_api(file=generate_test_path('integers.ion')):
-    table = execution_with_command(['write', file, '--api', 'simple_ion', '--api', 'event', '--api', 'event'])
-    assert gather_all_options_in_list(table) == sorted([('event', 'ion_binary', 'file'), ('simple_ion', 'ion_binary', 'file')])
+    table = execution_with_command(['write', file, '--api', 'load_dump', '--api', 'streaming', '--api', 'streaming'])
+    assert gather_all_options_in_list(table) == sorted(
+        [('streaming', 'ion_binary', 'file'), ('load_dump', 'ion_binary', 'file')])
 
 
 def test_read_multi_format(file=generate_test_path('integers.ion')):
     table = execution_with_command(['read', file, '--format', 'ion_text', '--format', 'ion_binary'])
-    assert gather_all_options_in_list(table) == sorted([('simple_ion', 'ion_binary', 'file'), ('simple_ion', 'ion_text', 'file')])
+    assert gather_all_options_in_list(table) == sorted(
+        [('load_dump', 'ion_binary', 'file'), ('load_dump', 'ion_text', 'file')])
 
 
 def test_write_multi_format(file=generate_test_path('integers.ion')):
     table = execution_with_command(['write', file, '--format', 'ion_text', '--format', 'ion_binary'])
-    assert gather_all_options_in_list(table) == sorted([('simple_ion', 'ion_text', 'file'), ('simple_ion', 'ion_binary', 'file')])
+    assert gather_all_options_in_list(table) == sorted(
+        [('load_dump', 'ion_text', 'file'), ('load_dump', 'ion_binary', 'file')])
 
 
 def test_read_multi_duplicated_format(file=generate_test_path('integers.ion')):
-    table = execution_with_command(['read', file, '--format', 'ion_text', '--format', 'ion_binary', '--format', 'ion_text'])
-    assert gather_all_options_in_list(table) == sorted([('simple_ion', 'ion_text', 'file'), ('simple_ion', 'ion_binary', 'file')])
+    table = execution_with_command(
+        ['read', file, '--format', 'ion_text', '--format', 'ion_binary', '--format', 'ion_text'])
+    assert gather_all_options_in_list(table) == sorted(
+        [('load_dump', 'ion_text', 'file'), ('load_dump', 'ion_binary', 'file')])
 
 
 def test_write_multi_duplicated_format(file=generate_test_path('integers.ion')):
-    table = execution_with_command(['write', file, '--format', 'ion_text', '--format', 'ion_binary', '--format', 'ion_text',])
-    assert gather_all_options_in_list(table) == sorted([('simple_ion', 'ion_text', 'file'), ('simple_ion', 'ion_binary', 'file')])
+    table = execution_with_command(
+        ['write', file, '--format', 'ion_text', '--format', 'ion_binary', '--format', 'ion_text', ])
+    assert gather_all_options_in_list(table) == sorted(
+        [('load_dump', 'ion_text', 'file'), ('load_dump', 'ion_binary', 'file')])
 
 
 @parametrize(
@@ -179,7 +258,7 @@ def test_write_multi_duplicated_format(file=generate_test_path('integers.ion')):
 )
 def test_write_json_format(f):
     table = execution_with_command(['write', generate_test_path('integers.ion'), '--format', f'{f}'])
-    assert gather_all_options_in_list(table) == sorted([('simple_ion', f'{f}', 'file')])
+    assert gather_all_options_in_list(table) == sorted([('load_dump', f'{f}', 'file')])
 
 
 @parametrize(
@@ -187,7 +266,7 @@ def test_write_json_format(f):
 )
 def test_read_json_format(f):
     table = execution_with_command(['read', generate_test_path('integers.ion'), '--format', f'{f}'])
-    assert gather_all_options_in_list(table) == sorted([('simple_ion', f'{f}', 'file')])
+    assert gather_all_options_in_list(table) == sorted([('load_dump', f'{f}', 'file')])
 
 
 @parametrize(
@@ -195,7 +274,7 @@ def test_read_json_format(f):
 )
 def test_write_cbor_format(f):
     table = execution_with_command(['write', generate_test_path('integers.ion'), '--format', f'{f}'])
-    assert gather_all_options_in_list(table) == sorted([('simple_ion', f'{f}', 'file')])
+    assert gather_all_options_in_list(table) == sorted([('load_dump', f'{f}', 'file')])
 
 
 @parametrize(
@@ -203,20 +282,49 @@ def test_write_cbor_format(f):
 )
 def test_read_cbor_format(f):
     table = execution_with_command(['read', generate_test_path('integers.ion'), '--format', f'{f}'])
-    assert gather_all_options_in_list(table) == sorted([('simple_ion', f'{f}', 'file')])
+    assert gather_all_options_in_list(table) == sorted([('load_dump', f'{f}', 'file')])
 
 
 @parametrize(
     *tuple((io.value for io in Io_type.Io_type))
 )
 def test_write_io_type(f):
-    table = execution_with_command(['write', generate_test_path('integers.ion'), '--io-type', f'{f}', '--format', 'json'])
-    assert gather_all_options_in_list(table) == sorted([('simple_ion', 'json', f'{f}')])
+    table = execution_with_command(
+        ['write', generate_test_path('integers.ion'), '--io-type', f'{f}', '--format', 'json'])
+    assert gather_all_options_in_list(table) == sorted([('load_dump', 'json', f'{f}')])
 
 
 @parametrize(
     *tuple((io.value for io in Io_type.Io_type))
 )
 def test_read_io_type(f):
-    table = execution_with_command(['read', generate_test_path('integers.ion'), '--io-type', f'{f}', '--format', 'json', '--format', 'ion_binary'])
-    assert gather_all_options_in_list(table) == sorted([('simple_ion', 'json', f'{f}'), ('simple_ion', 'ion_binary', f'{f}')])
+    table = execution_with_command(
+        ['read', generate_test_path('integers.ion'), '--io-type', f'{f}', '--format', 'json', '--format', 'ion_binary'])
+    assert gather_all_options_in_list(table) == sorted(
+        [('load_dump', 'json', f'{f}'), ('load_dump', 'ion_binary', f'{f}')])
+
+
+@parametrize(
+    *tuple((Format.Format.ION_TEXT, Format.Format.ION_BINARY))
+)
+def test_format_is_ion(f):
+    assert format_is_ion(f.value) is True
+
+
+@parametrize(
+    *tuple((Format.Format.JSON,
+            Format.Format.UJSON,
+            Format.Format.RAPIDJSON,
+            Format.Format.SIMPLEJSON
+            ))
+)
+def test_format_is_json(f):
+    assert format_is_json(f.value) is True
+
+
+@parametrize(
+    Format.Format.CBOR,
+    Format.Format.CBOR2
+)
+def test_format_is_cbor(f):
+    assert format_is_cbor(f.value) is True

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -82,10 +82,10 @@ def test_generate_json_read_test_code(path):
 def test_generate_cbor_read_test_code(path):
     actual = generate_read_test_code(path, memory_profiling=False, single_value=False,
                                      format_option=Format.Format.CBOR2.value, emit_bare_values=False,
-                                     io_type=Io_type.Io_type.FILE, binary=False)
+                                     io_type=Io_type.Io_type.FILE, binary=True)
 
     # make sure we generated the desired load function
-    with open(path) as fp:
+    with open(path, 'br') as fp:
         expect = cbor2.load(fp)
 
     # make sure the return values are same
@@ -109,7 +109,7 @@ def test_generate_simpleion_write_test_code(obj):
 
 
 @parametrize(
-    generate_test_path('./json/object.json'),
+    generate_test_path('json/object.json'),
 )
 def test_generate_json_write_test_code(file):
     with open(file) as fp:
@@ -125,7 +125,7 @@ def test_generate_json_write_test_code(file):
 
 
 @parametrize(
-    generate_test_path('./cbor/sample')
+    generate_test_path('cbor/sample')
 )
 def test_generate_cbor_write_test_code(file):
     with open(file, 'br') as fp:
@@ -257,7 +257,7 @@ def test_write_multi_duplicated_format(file=generate_test_path('integers.ion')):
     *tuple((f.value for f in Format.Format if Format.format_is_json(f.value)))
 )
 def test_write_json_format(f):
-    table = execution_with_command(['write', generate_test_path('integers.ion'), '--format', f'{f}'])
+    table = execution_with_command(['write', generate_test_path('json/object.json'), '--format', f'{f}'])
     assert gather_all_options_in_list(table) == sorted([('load_dump', f'{f}', 'file')])
 
 
@@ -265,7 +265,7 @@ def test_write_json_format(f):
     *tuple((f.value for f in Format.Format if Format.format_is_json(f.value)))
 )
 def test_read_json_format(f):
-    table = execution_with_command(['read', generate_test_path('integers.ion'), '--format', f'{f}'])
+    table = execution_with_command(['read', generate_test_path('json/object.json'), '--format', f'{f}'])
     assert gather_all_options_in_list(table) == sorted([('load_dump', f'{f}', 'file')])
 
 
@@ -273,7 +273,7 @@ def test_read_json_format(f):
     *tuple((f.value for f in Format.Format if Format.format_is_cbor(f.value)))
 )
 def test_write_cbor_format(f):
-    table = execution_with_command(['write', generate_test_path('integers.ion'), '--format', f'{f}'])
+    table = execution_with_command(['write', generate_test_path('cbor/sample'), '--format', f'{f}'])
     assert gather_all_options_in_list(table) == sorted([('load_dump', f'{f}', 'file')])
 
 
@@ -281,7 +281,7 @@ def test_write_cbor_format(f):
     *tuple((f.value for f in Format.Format if Format.format_is_cbor(f.value)))
 )
 def test_read_cbor_format(f):
-    table = execution_with_command(['read', generate_test_path('integers.ion'), '--format', f'{f}'])
+    table = execution_with_command(['read', generate_test_path('cbor/sample'), '--format', f'{f}'])
     assert gather_all_options_in_list(table) == sorted([('load_dump', f'{f}', 'file')])
 
 


### PR DESCRIPTION
# Description: 
This PR integrates JSON/CBOR into the benchmark CLI. It additionally adds an IO type option to decide which IO type of the Ion data will be benchmarked. 

# Details

In details, this PR adds below features/components
1. Enable the CLI tool to benchmark Ion data as well as modern JSON/CBOR libraries concurrently.
2. Adds an IO type option to allow the tool benchmark time for either read/write in-memory buffers or files.
3. A bunch of refactor and unit testing.

# Output Example
## Example One 
Benchmark load API for all JSON libraries as well as ION

**Command and Output:**
```
python amazon/ionbenchmark/ion_benchmark_cli.py read --format json --format orjson --format simplejson --format ion_text --format ion_binary --format ujson
```
<img width="800" alt="Screenshot 2023-03-09 at 5 53 25 PM" src="https://user-images.githubusercontent.com/67451029/224203064-ca80d9a6-9fb6-44ef-b789-24044acc4be4.png">


## Example Two 
Benchmark dumps API (--io-types buffer) for CBOR2,  and Ion_binary

**Command and Output:**
```
python amazon/ionbenchmark/ion_benchmark_cli.py write --io-type buffer --format cbor2 --format ion_binary test_unit_int
```
<img width="808" alt="Screenshot 2023-03-09 at 5 56 19 PM" src="https://user-images.githubusercontent.com/67451029/224203459-049ac635-3621-4129-92fd-1db8aca949d1.png">


## Example Three  
Benchmark dump (--io-types file) API for CBOR2,  and Ion_binary

**Command and Output:**
```
python amazon/ionbenchmark/ion_benchmark_cli.py write --io-type file --format cbor2 --format ion_binary test_unit_int
```
<img width="800" alt="Screenshot 2023-03-09 at 5 56 58 PM" src="https://user-images.githubusercontent.com/67451029/224203540-a1df9daf-d4f8-4fbd-877c-ddccf03c6c89.png">



# Follow-up issues
1. **Memory profiling enhancement**  
Currently, the tool only profile a memory usage peak. Due to the potential optimization Python may do, the memory usage metrics might be inaccurate after running different formats multiple execution times. Need more investigation for memory related metrics - https://github.com/amazon-ion/ion-python/issues/245
2. **Needs a tool to convert different file formats.** 
https://github.com/amazon-ion/ion-python/issues/234
3. **Needs pretty printed format options**
Right now, the options output in the output table is unclear. For example, (simpleion, ion_binary, file) represents that `--api` is simpleion, `--format` is ion_binary and `--io-type` is file. This needs improvement - https://github.com/amazon-ion/ion-python/issues/244. 





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
