### PR TITLE
Uses specific ion-c version to build ion-python.

### DIFF
--- a/install.py
+++ b/install.py
@@ -89,6 +89,9 @@ def _download_ionc():
 
         os.chdir(_CURRENT_ION_C_DIR)
 
+        # TODO Use ion-c 1.0.0 for now - https://github.com/amazon-ion/ion-python/issues/249
+        check_call(['git', 'reset', '--hard', 'v1.1.0'])
+
         # Initialize submodule.
         check_call(['git', 'submodule', 'update', '--init'])
 

--- a/install.py
+++ b/install.py
@@ -89,7 +89,7 @@ def _download_ionc():
 
         os.chdir(_CURRENT_ION_C_DIR)
 
-        # TODO Use ion-c 1.0.0 for now - https://github.com/amazon-ion/ion-python/issues/249
+        # TODO Use ion-c 1.1.0 for now - https://github.com/amazon-ion/ion-python/issues/249
         check_call(['git', 'reset', '--hard', 'v1.1.0'])
 
         # Initialize submodule.


### PR DESCRIPTION
Using ion-c 1.1.0 specifically for ion-python to mitigate the issue https://github.com/amazon-ion/ion-python/issues/249.







By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
