### PR TITLE
Define IonPyBool as Distinct Type

### DIFF
--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -144,12 +144,22 @@ def _ion_type_for(name, base_cls, ion_type=None):
     return IonPyValueType
 
 
-IonPyInt = _ion_type_for('IonPyInt', int)
-IonPyBool = IonPyInt
+IonPyInt = _ion_type_for('IonPyInt', int, IonType.INT)
 IonPyFloat = _ion_type_for('IonPyFloat', float, IonType.FLOAT)
 IonPyDecimal = _ion_type_for('IonPyDecimal', Decimal, IonType.DECIMAL)
 IonPyText = _ion_type_for('IonPyText', str)
 IonPyBytes = _ion_type_for('IonPyBytes', bytes)
+
+# All of our ion value types inherit from their python value types, for good or
+# ill. Python's builtin `bool` cannot be sub-classed and is itself a sub-class
+# of int so we just sub-class int directly for our Ion Boolean.
+# Considering that True == 1 and False == 0 this works as expected.
+IonPyBool = _ion_type_for('IonPyBool', int, IonType.BOOL)
+
+# We override __repr__ so Booleans show up as True|False and not 1|0.
+# The representation is consistent with other primitives in that it returns a
+# string repr of the value but not annotations.
+IonPyBool.__repr__ = lambda self: str(bool(self))
 
 
 class IonPySymbol(SymbolToken, _IonNature):

--- a/tests/test_equivalence.py
+++ b/tests/test_equivalence.py
@@ -149,12 +149,14 @@ _EQUIVS_INSTANTS = (
 )
 
 _NONEQUIVS = (
-    # For each tuple, each element is not equivalent to any other element equivalent under the Ion data model.
+    # For each tuple, each element is not equivalent to any other element
+    # under the Ion data model.
     (None, 0, _null(_IT.BOOL)),
     (True, False),
     (True, _bool(False)),
     (_bool(True), False),
     (_bool(True), _bool(False)),
+    (_bool(True), _int(1)),  # True == 1 in python but not in the ion datamodel
     (1, -1, 1.),
     (1, _int(-1), _float(1)),
     (_int(1), _int(-1)),


### PR DESCRIPTION
This change defines IonPyBool as it's own sub-class of int instead of
as an alias of IonPyInt.

Doing so removes the potential confusion around the python type and
__repr__ which could make Ion Booleans appear as Ion Ints.

gh issue: https://github.com/amazon-ion/ion-python/issues/88

After the change:
```
>>> from amazon.ion import simpleion
>>> b = simpleion.loads('true')
>>> b
True
>>> type(b)
<class 'amazon.ion.simple_types.IonPyBool'>
>>> b.ion_type
<IonType.BOOL: 1>
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
