### PR TITLE
Fix __repr__ of Empty Struct

### DIFF
--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -23,7 +23,7 @@ try:
     from collections import OrderedDict
 except:
     from collections import MutableMapping, MutableSequence, OrderedDict
-    
+
 from datetime import datetime, timedelta, tzinfo
 from decimal import Decimal, ROUND_FLOOR, Context, Inexact
 from math import isnan
@@ -635,10 +635,7 @@ class Multimap(MutableMapping):
         return repr(self)
 
     def __repr__(self):
-        str_repr = '{'
-        for key, value in self.items():
-            str_repr += '%r: %r, ' % (key, value)
-        return str_repr[:len(str_repr) - 2] + '}'
+        return '{%s}' % ', '.join(['%r: %r' % (k, v) for k, v in self.items()])
 
     def add_item(self, key, value):
         if key in self.__store:


### PR DESCRIPTION
This change fixes a bug where the empty Ion Struct was being
represented with only a closing brace.

After change:
```
>>> simpleion.loads('{}')
{}
>>> simpleion.loads('{"a":1}')
{'a': 1}
```

gh issue: https://github.com/amazon-ion/ion-python/issues/257

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
