### PR TITLE
fix: seek to previous position instead of 0 after reading IVM

### DIFF
--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -358,8 +358,9 @@ def load_python(fp, catalog=None, single_value=True, encoding='utf-8', cls=None,
     if isinstance(fp, _TEXT_TYPES):
         raw_reader = text_reader(is_unicode=True)
     else:
+        pos = fp.tell()
         maybe_ivm = fp.read(4)
-        fp.seek(0)
+        fp.seek(pos)
         if maybe_ivm == _IVM:
             raw_reader = binary_reader()
         else:


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amazon-ion/ion-python/issues/251

*Description of changes:* Remember current file position then seek back to it after reading the IVM instead of blindly seeking to position 0.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
