### PR TITLE
Replace Usages of record with NamedTuple

### DIFF
--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -314,11 +314,11 @@ class Transition(NamedTuple):
     This is generally used as a result of a state-machine.
 
     Args:
-        event (Union[DataEvent]): The event associated with the transition.
+        event (Optional[DataEvent]): The event associated with the transition.
         delegate (Coroutine): The co-routine delegate which can be the same routine from
             whence this transition came.
     """
-    event: DataEvent
+    event: Optional[DataEvent]
     delegate: Coroutine
 
 

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -18,12 +18,13 @@ from enum import IntEnum
 from functools import partial
 from io import BytesIO
 from struct import unpack
+from typing import NamedTuple, Optional, Sequence, Coroutine
 
 from .core import ION_STREAM_INCOMPLETE_EVENT, ION_STREAM_END_EVENT, ION_VERSION_MARKER_EVENT,\
                   IonEventType, IonType, IonEvent, IonThunkEvent, Transition, \
                   TimestampPrecision, Timestamp, OffsetTZInfo
 from .exceptions import IonException
-from .util import coroutine, record
+from .util import coroutine
 from .reader import reader_trampoline, BufferQueue, ReadEventType
 from .symbols import SYMBOL_ZERO_TOKEN, SymbolToken
 
@@ -207,9 +208,7 @@ def _parse_sid_iter(data):
         yield SymbolToken(None, sid)
 
 
-class _HandlerContext(record(
-        'position', 'limit', 'queue', 'field_name', 'annotations', 'depth', 'whence'
-    )):
+class _HandlerContext(NamedTuple):
     """A context for a handler co-routine.
 
     Args:
@@ -224,6 +223,15 @@ class _HandlerContext(record(
         whence (Coroutine): The reference to the co-routine that this handler should delegate
             back to when the handler is logically done.
     """
+    position: int
+    limit: Optional[int]
+    queue: BufferQueue
+    field_name: Optional[SymbolToken]
+    annotations: Optional[Sequence[SymbolToken]]
+    depth: int
+    whence: Coroutine
+
+
     @property
     def remaining(self):
         """Determines how many bytes are remaining in the current context."""

--- a/amazon/ion/reader_managed.py
+++ b/amazon/ion/reader_managed.py
@@ -13,6 +13,7 @@
 # License.
 
 """Provides symbol table managed processing for Ion readers."""
+from typing import NamedTuple
 
 from .core import IonEventType, IonType, IonThunkEvent, MemoizingThunk, Transition, \
                   ION_VERSION_MARKER_EVENT
@@ -22,16 +23,19 @@ from .symbols import SymbolTable, SymbolTableCatalog, \
                      LOCAL_TABLE_TYPE, SYSTEM_SYMBOL_TABLE, \
                      TEXT_ION, TEXT_ION_1_0, TEXT_ION_SYMBOL_TABLE, TEXT_SYMBOLS, TEXT_IMPORTS, \
                      TEXT_NAME, TEXT_VERSION, TEXT_MAX_ID
-from .util import coroutine, record
+from .util import coroutine
 
 
-class _ManagedContext(record('catalog', ('symbol_table', SYSTEM_SYMBOL_TABLE))):
+class _ManagedContext(NamedTuple):
     """Context for the managed reader.
 
     Args:
         catalog (SymbolTableCatalog): The catalog for this context.
         symbol_table (SymbolTable): The symbol table.
     """
+    catalog: SymbolTableCatalog
+    symbol_table: SymbolTable = SYSTEM_SYMBOL_TABLE
+
     def resolve(self, token):
         """Attempts to resolve the :class:`SymbolToken` against the current table.
 

--- a/amazon/ion/reader_text.py
+++ b/amazon/ion/reader_text.py
@@ -17,13 +17,14 @@ from decimal import Decimal
 from collections import defaultdict
 from enum import IntEnum
 from functools import partial
+from typing import Optional, NamedTuple
 
 from amazon.ion.core import Transition, ION_STREAM_INCOMPLETE_EVENT, ION_STREAM_END_EVENT, IonType, IonEvent, \
     IonEventType, IonThunkEvent, TimestampPrecision, timestamp, ION_VERSION_MARKER_EVENT
 from amazon.ion.exceptions import IonException
 from amazon.ion.reader import BufferQueue, reader_trampoline, ReadEventType, CodePointArray, CodePoint
 from amazon.ion.symbols import SymbolToken, TEXT_ION_1_0
-from amazon.ion.util import record, coroutine, _next_code_point, CodePoint
+from amazon.ion.util import coroutine, _next_code_point, CodePoint
 
 
 def _illegal_character(c, ctx, message=''):
@@ -235,9 +236,7 @@ _NULL_STARTS = {
 }
 
 
-class _ContainerContext(record(
-    'end', 'delimiter', 'ion_type', 'is_delimited'
-)):
+class _ContainerContext(NamedTuple):
     """A description of an Ion container, including the container's IonType and its textual delimiter and end character,
     if applicable.
 
@@ -251,6 +250,10 @@ class _ContainerContext(record(
         ion_type (Optional[IonType]): The container's IonType, if any.
         is_delimited (bool): True if delimiter is not empty; otherwise, False.
     """
+    end: tuple
+    delimiter: tuple
+    ion_type: Optional[IonType]
+    is_delimited: bool
 
 _C_TOP_LEVEL = _ContainerContext((), (), None, False)
 _C_STRUCT = _ContainerContext((_CLOSE_BRACE,), (_COMMA,), IonType.STRUCT, True)

--- a/amazon/ion/symbols.py
+++ b/amazon/ion/symbols.py
@@ -17,9 +17,9 @@ import itertools
 from itertools import chain
 from itertools import islice
 from itertools import repeat
+from typing import NamedTuple, Optional
 
 from .exceptions import CannotSubstituteTable
-from .util import record
 
 TEXT_ION = u'$ion'
 TEXT_ION_1_0 = u'$ion_1_0'
@@ -42,7 +42,7 @@ SID_MAX_ID = 8
 SID_ION_SHARED_SYMBOL_TABLE = 9
 
 
-class ImportLocation(record('name', 'position')):
+class ImportLocation(NamedTuple):
     """Represents the import location of a symbol token.
 
     An import location can be thought of as a position independent address of an imported symbol.
@@ -57,9 +57,11 @@ class ImportLocation(record('name', 'position')):
         name (unicode): The name of the shared symbol table.
         position (int): The position in the shared symbol table.
     """
+    name: str
+    position: int
 
 
-class SymbolToken(record('text', 'sid', 'location')):
+class SymbolToken(NamedTuple):
     """Representation of a *symbolic token*.
 
     A symbolic token may be a *part* of an Ion value in several contexts:
@@ -71,15 +73,14 @@ class SymbolToken(record('text', 'sid', 'location')):
     Args:
         text (Optional[unicode]): The text image of the token.
         sid  (Optional[int]): The local symbol ID of the token.
-        location (Optional[ImportTableLocation]): The import source of the token.
+        location (Optional[ImportLocation]): The import source of the token.
 
     Note:
         At least one of ``text`` or ``sid`` should be non-``None``
     """
-    def __new__(cls, text, sid, location=None):
-        if text is None and sid is None:
-            raise ValueError('SymbolToken must specify at least one of text or sid')
-        return super(SymbolToken, cls).__new__(cls, text, sid, location)
+    text: Optional[str]
+    sid: Optional[int]
+    location: Optional[ImportLocation] = None
 
 
 def _system_symbol_token(text, sid):
@@ -102,7 +103,7 @@ _SYSTEM_SYMBOL_TOKENS = (
 )
 
 
-class _SymbolTableType(record('is_system', 'is_shared', 'is_local')):
+class _SymbolTableType(NamedTuple):
     """A set of flags indicating attributes of a symbol table.
 
     Args:
@@ -110,6 +111,9 @@ class _SymbolTableType(record('is_system', 'is_shared', 'is_local')):
         is_shared (bool): Whether or not the symbol table is a is_shared table.
         is_local (bool): Whether or not the symbol table is is_local.
     """
+    is_system: bool
+    is_shared: bool
+    is_local: bool
 
 SYSTEM_TABLE_TYPE = _SymbolTableType(is_system=True, is_shared=True, is_local=False)
 SHARED_TABLE_TYPE = _SymbolTableType(is_system=False, is_shared=True, is_local=False)

--- a/amazon/ion/util.py
+++ b/amazon/ion/util.py
@@ -21,9 +21,17 @@ from warnings import warn
 
 
 class _RecordMetaClass(type):
-    """Metaclass for defining named-tuple based immutable record types."""
+    """Metaclass for defining named-tuple based immutable record types.
+
+        Deprecated: prefer the built-in NamedTuple
+    """
 
     def __new__(cls, name, bases, attrs):
+        warn(f'{cls.__name__} is an internal-only class in ion-python; do not use it for any reason. This '
+             f'class is deprecated and may be removed without further warning in any future release. Use `NamedTuple` '
+             f'instead.',
+             DeprecationWarning, stacklevel=2)
+
         if attrs.get('_record_sentinel') is None:
             field_declarations = []
             has_record_sentinel = False
@@ -328,6 +336,4 @@ class Enum(int, metaclass=_EnumMetaClass):
         return '<%s.%s: %s>' % (type(self).__name__, self.name, self.value)
 
     __repr__ = __str__
-
-
 

--- a/amazon/ion/writer_binary.py
+++ b/amazon/ion/writer_binary.py
@@ -14,13 +14,14 @@
 
 """Binary Ion writer with symbol table management."""
 from enum import IntEnum
+from typing import Optional, NamedTuple
 
-from .core import ION_STREAM_END_EVENT, IonEventType, IonType, IonEvent, DataEvent, Transition
+from .core import ION_STREAM_END_EVENT, IonEventType, IonType, IonEvent, DataEvent, Transition, SymbolTokenOrStr
 from .exceptions import IonException
 from .symbols import SID_ION_SYMBOL_TABLE, SID_IMPORTS, SHARED_TABLE_TYPE, \
                      SID_NAME, SID_VERSION, SID_MAX_ID, SID_SYMBOLS, LOCAL_TABLE_TYPE, \
                      SymbolTable, _SYSTEM_SYMBOL_TOKENS
-from .util import coroutine, record
+from .util import coroutine
 from .writer import NOOP_WRITER_EVENT, writer_trampoline, partial_transition, WriteEventType, \
                     _drain
 from .writer_binary_raw import _WRITER_EVENT_NEEDS_INPUT_EMPTY, _raw_binary_writer
@@ -43,7 +44,7 @@ class _SymbolEventType(IntEnum):
     FINISH = 2
 
 
-class _SymbolEvent(record('event_type', ('symbol', None))):
+class _SymbolEvent(NamedTuple):
     """Symbol event used by the managed writer coroutine to trigger an action in the symbol
     table coroutine.
 
@@ -51,8 +52,10 @@ class _SymbolEvent(record('event_type', ('symbol', None))):
 
     Args:
         event_type (_SymbolEventType): The type of symbol event.
-        symbol (Optional[SymbolToken | unicode]): The symbol token or text associated with the event.
+        symbol (Optional[SymbolTokenOrStr]): The symbol token or text associated with the event.
     """
+    event_type: _SymbolEventType
+    symbol: Optional[SymbolTokenOrStr] = None
 
 
 def _system_token(sid):

--- a/tests/reader_util.py
+++ b/tests/reader_util.py
@@ -11,13 +11,13 @@
 # OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the
 # License.
+from typing import NamedTuple, Sequence
 
 from pytest import raises
 
 from tests import is_exception, listify
 
 from amazon.ion.core import IonEventType
-from amazon.ion.util import record
 from tests.event_aliases import END
 from tests.event_aliases import NEXT
 
@@ -42,7 +42,11 @@ def add_depths(events):
                 depth += 1
 
 
-class ReaderParameter(record('desc', 'event_pairs', ('is_unicode', False))):
+class ReaderParameter(NamedTuple):
+    desc: str
+    event_pairs: Sequence
+    is_unicode: bool = False
+
     def __str__(self):
         return self.desc
 

--- a/tests/test_core_iontype.py
+++ b/tests/test_core_iontype.py
@@ -13,13 +13,17 @@
 # License.
 
 import itertools
+from typing import NamedTuple, Any
+
 import tests
 
 from amazon.ion.core import IonType
-from amazon.ion.util import record
 
 
-class _P(record('type', 'expected')):
+class _P(NamedTuple):
+    type: str
+    expected: Any
+
     def __str__(self):
         return '{name} - {expected}'.format(name=self.type.name, expected=str(self.expected).upper())
 

--- a/tests/test_core_multimap.py
+++ b/tests/test_core_multimap.py
@@ -1,9 +1,16 @@
-from amazon.ion.core import Multimap, record
+from typing import Sequence, NamedTuple
+
+from amazon.ion.core import Multimap
 
 from tests import parametrize
 
 
-class _P(record('pairs', 'expected_all_values', 'expected_single_value', 'expected_total_len')):
+class _P(NamedTuple):
+    pairs: Sequence
+    expected_all_values: Sequence
+    expected_single_value: Sequence
+    expected_total_len: int
+
     def __str__(self):
         return '{name}'.format(name=self.pairs)
 

--- a/tests/test_reader_base.py
+++ b/tests/test_reader_base.py
@@ -14,6 +14,7 @@
 
 from functools import partial
 from io import BytesIO
+from typing import NamedTuple, Coroutine, Sequence, Any
 
 from pytest import raises
 
@@ -27,7 +28,7 @@ from amazon.ion.core import ION_VERSION_MARKER_EVENT
 from amazon.ion.core import ION_STREAM_INCOMPLETE_EVENT, ION_STREAM_END_EVENT
 from amazon.ion.reader import read_data_event, reader_trampoline, blocking_reader
 from amazon.ion.reader import NEXT_EVENT, SKIP_EVENT
-from amazon.ion.util import coroutine, record
+from amazon.ion.util import coroutine
 
 
 _TRIVIAL_ION_EVENT = e_int(0)
@@ -38,7 +39,13 @@ _end_transition = partial(Transition, ION_STREAM_END_EVENT)
 _event_transition = partial(Transition, _TRIVIAL_ION_EVENT)
 
 
-class ReaderTrampolineParameters(record('desc', 'coroutine', 'input', 'expected', ('allow_flush', False))):
+class ReaderTrampolineParameters(NamedTuple):
+    desc: str
+    coroutine: Coroutine
+    input: Sequence[Any]
+    expected: Sequence[Any]
+    allow_flush: bool = False
+
     def __str__(self):
         return self.desc
 
@@ -134,7 +141,13 @@ def test_trampoline(p):
     trampoline_scaffold(reader_trampoline, p, p.allow_flush)
 
 
-class _P(record('desc', 'coroutine', 'data', 'input', 'expected')):
+class _P(NamedTuple):
+    desc: str
+    coroutine: Coroutine
+    data: Any
+    input: Any
+    expected: Any
+
     def __str__(self):
         return self.desc
 

--- a/tests/test_reader_buffer.py
+++ b/tests/test_reader_buffer.py
@@ -11,13 +11,13 @@
 # OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the
 # License.
+from typing import Callable, Sequence, NamedTuple
 
 from pytest import raises
 
 from tests import parametrize
 
 from amazon.ion.reader import BufferQueue, CodePointArray
-from amazon.ion.util import record
 
 
 def read(expected):
@@ -100,7 +100,11 @@ def expect_eof(is_eof):
     return action
 
 
-class _P(record('desc', 'actions', ('is_unicode', False))):
+class _P(NamedTuple):
+    desc: str
+    actions: Sequence[Callable]
+    is_unicode: bool = False
+
     def __str__(self):
         return self.desc
 

--- a/tests/test_reader_managed.py
+++ b/tests/test_reader_managed.py
@@ -13,6 +13,7 @@
 # License.
 
 from itertools import chain
+from typing import Sequence, Any, NamedTuple
 
 from tests import parametrize, listify
 from tests.reader_util import reader_scaffold, add_depths
@@ -27,7 +28,7 @@ from amazon.ion.symbols import shared_symbol_table, local_symbol_table, \
                                TEXT_ION, TEXT_ION_1_0, TEXT_ION_SYMBOL_TABLE, \
                                TEXT_NAME, TEXT_VERSION, TEXT_MAX_ID, \
                                TEXT_IMPORTS, TEXT_SYMBOLS
-from amazon.ion.util import coroutine, record
+from amazon.ion.util import coroutine
 
 _DATA = e_read(b'DUMMY')
 
@@ -159,7 +160,12 @@ def _predefined_reader(event_pairs):
         output = next(output_iter)
 
 
-class _P(record('desc', 'outer', 'inner', ('catalog', None))):
+class _P(NamedTuple):
+    desc: str
+    outer: Sequence
+    inner: Sequence
+    catalog: Any = None
+
     def __str__(self):
         return self.desc
 

--- a/tests/test_simple_types.py
+++ b/tests/test_simple_types.py
@@ -14,16 +14,16 @@
 
 from datetime import datetime
 from decimal import Decimal
+from typing import Type, NamedTuple
 
 from tests import parametrize, listify
 from tests.event_aliases import *
 
 from amazon.ion.core import Timestamp, TimestampPrecision
-from amazon.ion.util import record
 from amazon.ion.symbols import SymbolToken
 from amazon.ion.simple_types import is_null, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, \
-                                    IonPyDecimal, IonPyTimestamp, IonPyText, IonPyBytes, \
-                                    IonPyList, IonPyDict, IonPySymbol
+    IonPyDecimal, IonPyTimestamp, IonPyText, IonPyBytes, \
+    IonPyList, IonPyDict, IonPySymbol, _IonNature
 from amazon.ion.equivalence import ion_equals
 from amazon.ion.simpleion import _ion_type, _FROM_TYPE
 
@@ -31,7 +31,11 @@ _TEST_FIELD_NAME = SymbolToken('foo', 10)
 _TEST_ANNOTATIONS = (SymbolToken('bar', 11),)
 
 
-class _P(record('desc', 'type', 'event')):
+class _P(NamedTuple):
+    desc: str
+    type: Type[_IonNature]
+    event: IonEvent
+
     def __str__(self):
         return self.desc
 

--- a/tests/test_symbols_catalog.py
+++ b/tests/test_symbols_catalog.py
@@ -11,6 +11,7 @@
 # OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the
 # License.
+from typing import Any, NamedTuple
 
 from pytest import raises
 
@@ -19,8 +20,6 @@ from tests import parametrize, is_exception
 import amazon.ion.symbols as symbols
 
 from amazon.ion.exceptions import CannotSubstituteTable
-from amazon.ion.util import record
-
 
 FOO_1_TEXTS = (u'aa', u'bb', u'cc')
 FOO_1_TABLE = symbols.shared_symbol_table(
@@ -52,7 +51,13 @@ REGISTER_TABLES = (
 )
 
 
-class _P(record('desc', 'name', 'version', 'max_id', 'expected')):
+class _P(NamedTuple):
+    desc: str
+    name: str
+    version: int
+    max_id: int
+    expected: Any
+
     def __str__(self):
         return '{p.desc} - {p.name}, {p.version}, {p.max_id}'.format(p=self)
 
@@ -136,7 +141,11 @@ def test_catalog(p):
         assert p.expected == resolved
 
 
-class _P(record('desc', 'table', ('expected', ValueError))):
+class _P(NamedTuple):
+    desc: str
+    table: symbols.SymbolTable
+    expected: Any = ValueError
+
     def __str__(self):
         return self.desc
 

--- a/tests/test_symbols_table.py
+++ b/tests/test_symbols_table.py
@@ -14,18 +14,13 @@
 
 import functools
 import itertools
+from typing import NamedTuple, Sequence, Optional, Type
+
 import pytest
 
 import tests
 
 import amazon.ion.symbols as symbols
-
-from amazon.ion.util import record
-
-
-def test_symbol_token_no_text_or_sid():
-    with pytest.raises(ValueError):
-        symbols.SymbolToken(None, None)
 
 
 def test_system_symbols():
@@ -56,9 +51,14 @@ def test_system_symbols():
         )
 
 
-class _P(record('name', 'version', 'symbols', ('exc', ValueError))):
+class _P(NamedTuple):
+    name: Optional[str]
+    version: Optional[int]
+    symbols: Sequence[str]
+    exc: Type[Exception] = ValueError
+
     def __str__(self):
-        return  '{p.name!r}, {p.version}, {p.symbols!r}'.format(p = self)
+        return '{p.name!r}, {p.version}, {p.symbols!r}'.format(p = self)
 
 
 @tests.parametrize(
@@ -70,7 +70,7 @@ class _P(record('name', 'version', 'symbols', ('exc', ValueError))):
     _P(name=b'my_shared', version=1, symbols=[], exc=TypeError),
     _P(name=u'my_shared', version=1, symbols=[b'a'], exc=TypeError),
 )
-def test_shared_symbls_malformed(p):
+def test_shared_symbols_malformed(p):
     with pytest.raises(p.exc):
         symbols.shared_symbol_table(p.name, p.version, p.symbols)
 
@@ -104,7 +104,14 @@ SUB_SOURCE_EQUAL_SYMBOLS = symbols.substitute_symbol_table(BAR_TABLE, 2, 6)
 SUB_SOURCE_EQUAL_TEXTS = BAR_TEXTS
 
 
-class _P(record('desc', 'table', 'name', 'version', 'is_substitute', 'symbol_texts')):
+class _P(NamedTuple):
+    desc: str
+    table: symbols.SymbolTable
+    name: str
+    version: int
+    is_substitute: bool
+    symbol_texts: Sequence[Optional[str]]
+
     def __str__(self):
         return  self.desc
 
@@ -203,7 +210,10 @@ def test_shared_symbols_intern():
         FOO_TABLE.intern(u'hello')
 
 
-class _P(record('name', 'version')):
+class _P(NamedTuple):
+    name: Optional[str]
+    version: Optional[int]
+
     def __str__(self):
         return '{p.name!r} {p.version!r}'.format(p=self)
 
@@ -235,7 +245,13 @@ _SID_START = len(symbols.SYSTEM_SYMBOL_TABLE) + 1
 _COLLIDE_SID_START = len(symbols.SYSTEM_SYMBOL_TABLE) + len(COLLIDE_TABLE) + 1
 
 
-class _P(record('desc', 'symbol_texts', 'tokens', ('imports', ()), ('symbol_count_override', None))):
+class _P(NamedTuple):
+    desc: str
+    symbol_texts: Sequence[str]
+    tokens: Sequence[symbols.SymbolToken]
+    imports: Sequence = ()
+    symbol_count_override: Optional[int] = None
+
     def __str__(self):
         return self.desc
 

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -16,7 +16,7 @@ from decimal import Decimal
 
 import pytest
 
-from amazon.ion.core import Timestamp, TimestampPrecision, record, TIMESTAMP_MICROSECOND_FIELD
+from amazon.ion.core import Timestamp, TimestampPrecision, TIMESTAMP_MICROSECOND_FIELD
 from amazon.ion.equivalence import ion_equals
 from tests import parametrize, listify
 

--- a/tests/test_util_unicode.py
+++ b/tests/test_util_unicode.py
@@ -11,19 +11,24 @@
 # OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the
 # License.
+from typing import NamedTuple, Any
 
 from pytest import raises
 
 from tests import parametrize, is_exception, noop_manager
 
-from amazon.ion.util import record, unicode_iter
+from amazon.ion.util import unicode_iter
 
 
 def _unichr_list(val):
     return list(ord(x) for x in val)
 
 
-class _P(record('desc', 'input', 'expected')):
+class _P(NamedTuple):
+    desc: str
+    input: str
+    expected: Any
+
     def __str__(self):
         return self.desc
 

--- a/tests/test_writer_text.py
+++ b/tests/test_writer_text.py
@@ -19,9 +19,9 @@ from io import BytesIO
 from itertools import chain
 
 from decimal import Decimal
+from typing import NamedTuple
 
 from amazon.ion.core import OffsetTZInfo, IonEvent, IonType, IonEventType
-from amazon.ion.core import record
 from amazon.ion.exceptions import IonException
 
 from tests import parametrize
@@ -243,7 +243,11 @@ def test_valid_indent_strs(p):
         ion_val = loads('[a, {x:2, y: height::17}]')
         assert ion_val == loads(dumps(ion_val, binary=False, indent=indent))
 
-class _P_Q(record('symbol', 'needs_quotes', ('backslash_required', False))):
+class _P_Q(NamedTuple):
+    symbol: str
+    needs_quotes: bool
+    backslash_required: bool = False
+
     pass
 
 @parametrize(

--- a/tests/trampoline_util.py
+++ b/tests/trampoline_util.py
@@ -11,12 +11,13 @@
 # OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the
 # License.
+from typing import Coroutine, Any, NamedTuple
 
 from pytest import raises
 
 from tests import is_exception
 
-from amazon.ion.util import coroutine, record
+from amazon.ion.util import coroutine
 
 
 @coroutine
@@ -46,7 +47,12 @@ def yields_iter(*seq):
         yield val
 
 
-class TrampolineParameters(record('desc', 'coroutine', 'input', 'expected')):
+class TrampolineParameters(NamedTuple):
+    desc: str
+    coroutine: Coroutine
+    input: Any
+    expected: Any
+
     def __str__(self):
         return self.desc
 

--- a/tests/writer_util.py
+++ b/tests/writer_util.py
@@ -18,12 +18,13 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 
 import sys
+from typing import NamedTuple, Sequence, Any
+
 from pytest import raises
 
 from amazon.ion.core import ION_STREAM_END_EVENT, IonEventType, IonEvent, IonType, timestamp, OffsetTZInfo, \
     TimestampPrecision
 from amazon.ion.symbols import SYMBOL_ZERO_TOKEN, SymbolToken
-from amazon.ion.util import record
 from amazon.ion.writer import WriteEventType
 from tests import is_exception
 from tests import noop_manager
@@ -38,7 +39,11 @@ _DT = datetime
 _IT = IonType
 
 
-class WriterParameter(record('desc', 'events', 'expected')):
+class WriterParameter(NamedTuple):
+    desc: str
+    events: Sequence[IonEvent]
+    expected: Any
+
     def __str__(self):
         return self.desc
 


### PR DESCRIPTION
This change replaces all of the usages of the record super-type
constructor with the built-in NamedTuple. This makes the code easier
to read (no custom special type mojo) and enables IDEs and other tooling
to provide type hints when constructing and field name completion when
using instances.

The types which extend NamedTuple are immutable as they were before.
I'm sure there was a reason record was created initially, but I don't
see a good reason to keep it now, particularly given the benefits of
just using NamedTuple.

I kept the record constructor and metaclass to avoid breaking a
consumer who is using them. We can remove them when we release an MV.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
