### PR TITLE
Update the version of setuptools to 65.5.1 or later

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pytest-runner==5.3.1
 toml==0.10.2
 tox==3.23.1
 virtualenv==20.4.7
-setuptools<=60.5.0
+setuptools>=65.5.1
 docopt==0.6.2
 tabulate==0.9.0
 simplejson~=3.18.3


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
This PR updates the version of `setuptools` to `65.5.1` or later to resolve the[ Dependabot alert ](https://github.com/amazon-ion/ion-python/security/dependabot/2).

> Python Packaging Authority (PyPA)'s setuptools is a library designed to facilitate packaging Python projects. Setuptools version 65.5.0 and earlier could allow remote attackers to cause a denial of service by fetching malicious HTML from a PyPI package or custom PackageIndex page due to a vulnerable Regular Expression in package_index. This has been patched in version 65.5.1.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
