### PR TITLE
Binary Reader Performance Refactor

### DIFF
--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -276,7 +276,7 @@ class IonThunkEvent(IonEvent):
 
     The `value` will be materialized on first access and cached.
 
-    Accessing the value by it's slot: ``event[2]`` will avoid materialization.
+    Accessing the value by its slot: ``event[2]`` will avoid materialization.
     """
 
     @property

--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -11,7 +11,6 @@
 # OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the
 # License.
-
 from enum import IntEnum
 from typing import NamedTuple, Optional, Any, Union, Sequence, Coroutine
 
@@ -272,21 +271,20 @@ class MemoizingThunk(object):
 
 
 class IonThunkEvent(IonEvent):
-    """An :class:`IonEvent` whose ``value`` field is a thunk."""
-    def __new__(cls, *args, **kwargs):
-        if len(args) >= 3:
-            args = list(args)
-            args[2] = MemoizingThunk(args[2])
-        else:
-            value = kwargs.get('value')
-            if value is not None:
-                kwargs['value'] = MemoizingThunk(kwargs['value'])
-        return super(IonThunkEvent, cls).__new__(cls, *args, **kwargs)
+    """
+    A lazy `IonEvent` whose ``value`` field is a thunk.
+
+    The `value` will be materialized on first access and cached.
+
+    Accessing the value by it's slot: ``event[2]`` will avoid materialization.
+    """
 
     @property
     def value(self):
-        # We're masking the value field, this gets around that.
-        return self[2]()
+        if hasattr(self, 'cached_value'):
+            return self.cached_value
+        self.cached_value = self[2]()
+        return self.cached_value
 
 # Singletons for structural events
 ION_STREAM_END_EVENT = IonEvent(IonEventType.STREAM_END)
@@ -314,11 +312,11 @@ class Transition(NamedTuple):
     This is generally used as a result of a state-machine.
 
     Args:
-        event (Optional[DataEvent]): The event associated with the transition.
+        event (Union[DataEvent, IonEvent, None]): The event associated with the transition.
         delegate (Coroutine): The co-routine delegate which can be the same routine from
             whence this transition came.
     """
-    event: Optional[DataEvent]
+    event: Union[DataEvent, IonEvent, None]
     delegate: Coroutine
 
 

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -11,21 +11,22 @@
 # OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the
 # License.
-
+from collections import deque
 from datetime import timedelta
 from decimal import Decimal, localcontext
 from enum import IntEnum
 from functools import partial
 from io import BytesIO
 from struct import unpack
-from typing import NamedTuple, Optional, Sequence, Coroutine
+from typing import NamedTuple, Optional, Sequence, Callable, Tuple, List
 
-from .core import ION_STREAM_INCOMPLETE_EVENT, ION_STREAM_END_EVENT, ION_VERSION_MARKER_EVENT,\
-                  IonEventType, IonType, IonEvent, IonThunkEvent, Transition, \
-                  TimestampPrecision, Timestamp, OffsetTZInfo
+from .core import ION_STREAM_INCOMPLETE_EVENT, ION_STREAM_END_EVENT, ION_VERSION_MARKER_EVENT, \
+    IonEventType, IonType, IonEvent, IonThunkEvent, \
+    TimestampPrecision, Timestamp, OffsetTZInfo
 from .exceptions import IonException
+from .sliceable_buffer import SliceableBuffer, IncompleteReadError
 from .util import coroutine
-from .reader import reader_trampoline, BufferQueue, ReadEventType
+from .reader import ReadEventType
 from .symbols import SYMBOL_ZERO_TOKEN, SymbolToken
 
 
@@ -181,7 +182,6 @@ def _parse_signed_int_components(buf):
 
 def _parse_decimal(buf):
     """Parses the remainder of a file-like object as a decimal."""
-    from decimal import localcontext
     exponent = _parse_var_int(buf, signed=True)
     sign_bit, coefficient = _parse_signed_int_components(buf)
 
@@ -208,406 +208,275 @@ def _parse_sid_iter(data):
         yield SymbolToken(None, sid)
 
 
-class _HandlerContext(NamedTuple):
-    """A context for a handler co-routine.
-
-    Args:
-        position (int): The offset of the *start* of the data being parsed.
-        limit (Optional[int]): The logical offset that represents the *end* of the container.
-        queue (BufferQueue): The data source for the handler.
-        field_name (Optional[SymbolToken]): The token representing the field name for the handled
-            value.
-        annotations (Optional[Sequence[SymbolToken]]): The sequence of annotations tokens
-            for the value to be parsed.
-        depth (int): the depth of the parser.
-        whence (Coroutine): The reference to the co-routine that this handler should delegate
-            back to when the handler is logically done.
-    """
-    position: int
-    limit: Optional[int]
-    queue: BufferQueue
-    field_name: Optional[SymbolToken]
-    annotations: Optional[Sequence[SymbolToken]]
+class _ParserContext(NamedTuple):
+    buffer: SliceableBuffer
     depth: int
-    whence: Coroutine
 
 
-    @property
-    def remaining(self):
-        """Determines how many bytes are remaining in the current context."""
-        if self.depth == 0:
-            return _STREAM_REMAINING
-        return self.limit - self.queue.position
-
-    def read_data_transition(self, length, whence=None,
-                             skip=False, stream_event=ION_STREAM_INCOMPLETE_EVENT):
-        """Returns an immediate event_transition to read a specified number of bytes."""
-        if whence is None:
-            whence = self.whence
-
-        return Transition(
-            None, _read_data_handler(length, whence, self, skip, stream_event)
-        )
-
-    def event_transition(self, event_cls, event_type,
-                         ion_type=None, value=None, annotations=None, depth=None, whence=None):
-        """Returns an ion event event_transition that yields to another co-routine.
-
-        If ``annotations`` is not specified, then the ``annotations`` are the annotations of this
-        context.
-        If ``depth`` is not specified, then the ``depth`` is depth of this context.
-        If ``whence`` is not specified, then ``whence`` is the whence of this context.
-        """
-        if annotations is None:
-            annotations = self.annotations
-        if annotations is None:
-            annotations = ()
-        if not (event_type is IonEventType.CONTAINER_START) and \
-                annotations and (self.limit - self.queue.position) != 0:
-            # This value is contained in an annotation wrapper, from which its limit was inherited. It must have
-            # reached, but not surpassed, that limit.
-            raise IonException('Incorrect annotation wrapper length.')
-
-        if depth is None:
-            depth = self.depth
-
-        if whence is None:
-            whence = self.whence
-
-        return Transition(
-            event_cls(event_type, ion_type, value, self.field_name, annotations, depth),
-            whence
-        )
-
-    def immediate_transition(self, delegate=None):
-        """Returns an immediate transition to another co-routine.
-
-        If ``delegate`` is not specified, then ``whence`` is the delegate.
-        """
-        if delegate is None:
-            delegate = self.whence
-
-        return Transition(None, delegate)
-
-    def derive_container_context(self, length, add_depth=1):
-        new_limit = self.queue.position + length
-        return _HandlerContext(
-            self.position,
-            new_limit,
-            self.queue,
-            self.field_name,
-            self.annotations,
-            self.depth + add_depth,
-            self.whence
-        )
-
-    def derive_child_context(self, position, field_name, annotations, whence):
-        return _HandlerContext(
-            position,
-            self.limit,
-            self.queue,
-            field_name,
-            annotations,
-            self.depth,
-            whence
-        )
-
-
-#
-# Handler Co-routine Factories
-#
-
-
-def _create_delegate_handler(delegate):
-    """Creates a handler function that creates a co-routine that can yield once with the given
-    positional arguments to the delegate as a transition.
-
-    Args:
-        delegate (Coroutine): The co-routine to delegate to.
-
-    Returns:
-        A :class:`callable` handler that returns a co-routine that ignores the data it receives
-        and sends with the arguments given to the handler as a :class:`Transition`.
-    """
-    @coroutine
-    def handler(*args):
-        yield
-        yield delegate.send(Transition(args, delegate))
-
-    return handler
-
-
-@coroutine
-def _read_data_handler(length, whence, ctx, skip=False, stream_event=ION_STREAM_INCOMPLETE_EVENT):
-    """Creates a co-routine for retrieving data up to a requested size.
-
-    Args:
-        length (int): The minimum length requested.
-        whence (Coroutine): The co-routine to return to after the data is satisfied.
-        ctx (_HandlerContext): The context for the read.
-        skip (Optional[bool]): Whether the requested number of bytes should be skipped.
-        stream_event (Optional[IonEvent]): The stream event to return if no bytes are read or
-            available.
-    """
-    trans = None
-    queue = ctx.queue
-
-    if length > ctx.remaining:
-        raise IonException('Length overrun: %d bytes, %d remaining' % (length, ctx.remaining))
-
-    # Make sure to check the queue first.
-    queue_len = len(queue)
-    if queue_len > 0:
-        # Any data available means we can only be incomplete.
-        stream_event = ION_STREAM_INCOMPLETE_EVENT
-    length -= queue_len
-
-    if skip:
-        # For skipping we need to consume any remnant in the buffer queue.
-        if length >= 0:
-            queue.skip(queue_len)
-        else:
-            queue.skip(queue_len + length)
-
-    while True:
-        data_event, self = (yield trans)
-        if data_event is not None and data_event.data is not None:
-            data = data_event.data
-            data_len = len(data)
-            if data_len > 0:
-                # We got something so we can only be incomplete.
-                stream_event = ION_STREAM_INCOMPLETE_EVENT
-            length -= data_len
-            if not skip:
-                queue.extend(data)
-            else:
-                pos_adjustment = data_len
-                if length < 0:
-                    pos_adjustment += length
-                    # More data than we need to skip, so make sure to accumulate that remnant.
-                    queue.extend(data[length:])
-                queue.position += pos_adjustment
-        if length <= 0:
-            # We got all the data we need, go back immediately
-            yield Transition(None, whence)
-
-        trans = Transition(stream_event, self)
-
-
-@coroutine
 def _invalid_handler(type_octet, ctx):
     """Placeholder co-routine for invalid type codes."""
-    yield
-    raise IonException('Invalid type octet: 0x%02X' % type_octet)
+    raise IonException(f'Invalid type octet: {type_octet}')
 
 
-@coroutine
-def _var_uint_field_handler(handler, ctx):
+def _var_uint_field_parser(buffer):
+    """
+    Parse a Var UInt.
+
+    Return (value, byte_ct) where value is the VarUInt and byte_ct
+    is the length of the VarUInt.
+    """
+    value = 0
+    while True:
+        (octet, buffer) = buffer.read_byte()
+        value <<= _VAR_INT_VALUE_BITS
+        value |= octet & _VAR_INT_VALUE_MASK
+        if octet & _VAR_INT_SIGNAL_MASK:
+            break
+    return value, buffer
+
+
+def _var_uint_field_handler(handler, context: _ParserContext):
     """Handler co-routine for variable unsigned integer fields that.
 
     Invokes the given ``handler`` function with the read field and context,
     then immediately yields to the resulting co-routine.
     """
-    _, self = yield
-    queue = ctx.queue
-    value = 0
-    while True:
-        if len(queue) == 0:
-            # We don't know when the field ends, so read at least one byte.
-            yield ctx.read_data_transition(1, self)
-        octet = queue.read_byte()
-        value <<= _VAR_INT_VALUE_BITS
-        value |= octet & _VAR_INT_VALUE_MASK
-        if octet & _VAR_INT_SIGNAL_MASK:
-            break
-    yield ctx.immediate_transition(handler(value, ctx))
+    (buffer, depth) = context
+    length, buffer = _var_uint_field_parser(buffer)
+    return handler(length, _ParserContext(buffer, depth))
 
 
-@coroutine
-def _ivm_handler(ctx):
-    _, self = yield
+def _ivm_handler(context: _ParserContext):
+    (buffer, depth) = context
+    if depth != 0:
+        raise IonException("Ion version markers are only valid at the top-level!")
 
-    if ctx.depth != 0:
-        raise IonException('IVM encountered below top-level')
-
-    yield ctx.read_data_transition(_IVM_TAIL_LEN, self)
-    ivm_tail = ctx.queue.read(_IVM_TAIL_LEN)
+    (ivm_tail, buffer) = buffer.read_slice(_IVM_TAIL_LEN)
     if _IVM_TAIL != ivm_tail:
-        raise IonException('Invalid IVM tail: %r' % ivm_tail)
-    yield Transition(ION_VERSION_MARKER_EVENT, ctx.whence)
+        raise IonException('Invalid version marker: %r' % ivm_tail)
+
+    return ION_VERSION_MARKER_EVENT, buffer
 
 
-@coroutine
-def _nop_pad_handler(ion_type, length, ctx):
-    yield
+def _nop_pad_handler(_, length, context: _ParserContext):
+    if not length:
+        return None, context.buffer
 
-    if ctx.field_name is not None and ctx.field_name != SYMBOL_ZERO_TOKEN:
-        raise IonException(
-            'Cannot have NOP pad with non-zero symbol field, field SID %d' % ctx.field_name)
+    (skipped, buffer) = context.buffer.skip(length)
+    if skipped < length:
+        raise IncompleteReadError("Couldn't complete skip!")
 
-    if length > 0:
-        yield ctx.read_data_transition(length, ctx.whence, skip=True)
-
-    # Nothing to skip, so we just go back from whence we came...
-    yield ctx.immediate_transition()
+    return None, buffer
 
 
-@coroutine
-def _static_scalar_handler(ion_type, value, ctx):
-    yield
-    yield ctx.event_transition(IonEvent, IonEventType.SCALAR, ion_type, value)
+def _static_scalar_handler(ion_type, value, context: _ParserContext):
+    return IonEvent(IonEventType.SCALAR, ion_type, value, depth=context.depth), context.buffer
 
 
-@coroutine
-def _length_scalar_handler(scalar_factory, ion_type, length, ctx):
+def _length_scalar_handler(scalar_factory, ion_type, length, context: _ParserContext):
     """Handles scalars, ``scalar_factory`` is a function that returns a value or thunk."""
-    _, self = yield
+    (buffer, depth) = context
     if length == 0:
         data = b''
     else:
-        yield ctx.read_data_transition(length, self)
-        data = ctx.queue.read(length)
+        (data, buffer) = buffer.read_slice(length)
 
     scalar = scalar_factory(data)
-    event_cls = IonEvent
     if callable(scalar):
-        # TODO Wrap the exception to get context position.
-        event_cls = IonThunkEvent
-    yield ctx.event_transition(event_cls, IonEventType.SCALAR, ion_type, scalar)
-
-
-@coroutine
-def _start_type_handler(field_name, whence, ctx, expects_ivm=False, at_top=False, annotations=None):
-    _, self = yield
-
-    child_position = ctx.queue.position
-
-    # Read type byte.
-    if at_top:
-        incomplete_event = ION_STREAM_END_EVENT
+        event = IonThunkEvent(IonEventType.SCALAR, ion_type, scalar, depth=context.depth)
     else:
-        incomplete_event = ION_STREAM_INCOMPLETE_EVENT
-    yield ctx.read_data_transition(1, self, stream_event=incomplete_event)
-    type_octet = ctx.queue.read_byte()
+        event = IonEvent(IonEventType.SCALAR, ion_type, scalar, depth=context.depth)
 
-    if expects_ivm and type_octet != _IVM_START_OCTET:
-        raise IonException(
-            'Expected binary version marker, got: %02X' % type_octet)
-
-    handler = _HANDLER_DISPATCH_TABLE[type_octet]
-    child_ctx = ctx.derive_child_context(child_position, field_name, annotations, whence)
-    yield ctx.immediate_transition(handler(child_ctx))
+    return event, buffer
 
 
-@coroutine
-def _annotation_handler(ion_type, length, ctx):
-    """Handles annotations.  ``ion_type`` is ignored."""
-    _, self = yield
-    self_handler = _create_delegate_handler(self)
+def _annotation_handler(_, length, context: _ParserContext):
+    (buffer, depth) = context
+    init_size = buffer.size
+    anno_length, buffer = _var_uint_field_parser(buffer)
 
-    if ctx.annotations is not None:
-        raise IonException('Annotation cannot be nested in annotations')
-
-    # We have to replace our context for annotations specifically to encapsulate the limit
-    ctx = ctx.derive_container_context(length, add_depth=0)
-    # Immediately read the length field and the annotations
-    (ann_length, _), _ = yield ctx.immediate_transition(
-        _var_uint_field_handler(self_handler, ctx)
-    )
-
-    if ann_length < 1:
+    if anno_length < 1:
         raise IonException('Invalid annotation length subfield; annotation wrapper must have at least one annotation.')
 
-    # Read/parse the annotations.
-    yield ctx.read_data_transition(ann_length, self)
-    ann_data = ctx.queue.read(ann_length)
-    annotations = tuple(_parse_sid_iter(ann_data))
+    (anno_bytes, buffer) = buffer.read_slice(anno_length)
+    annotations = tuple(_parse_sid_iter(anno_bytes))
 
-    if ctx.limit - ctx.queue.position < 1:
-        # There is no space left for the 'value' subfield, which is required.
-        raise IonException('Incorrect annotation wrapper length.')
+    if length - (init_size - buffer.size) < 1:
+        raise IonException("Invalid annotation length subfield; annotation wrapper must wrap non-zero length value.")
 
-    # Go parse the start of the value but go back to the real parent container.
-    yield ctx.immediate_transition(
-        _start_type_handler(ctx.field_name, ctx.whence, ctx, annotations=annotations)
-    )
+    event, buffer = _tlv_parser(_ParserContext(buffer, depth))
+
+    # nop padding comes back as none
+    if event is None:
+        raise IonException("Cannot annotate nop padding!")
+
+    if event.annotations:
+        raise IonException("Cannot nest annotations!")
+
+    actual_length = init_size - buffer.size
+    if event.event_type is IonEventType.CONTAINER_START:
+        actual_length += event.value
+    if actual_length != length:
+        raise IonException(f"Expected wrapped value to have length of {length} \
+                but was {actual_length}")
+
+    return event.derive_annotations(annotations), buffer
 
 
-@coroutine
-def _ordered_struct_start_handler(handler, ctx):
-    """Handles the special case of ordered structs, specified by the type ID 0xD1.
-
-    This coroutine's only purpose is to ensure that the struct in question declares at least one field name/value pair,
-    as required by the spec.
-    """
-    _, self = yield
-    self_handler = _create_delegate_handler(self)
-    (length, _), _ = yield ctx.immediate_transition(
-        _var_uint_field_handler(self_handler, ctx)
-    )
+def _ordered_struct_start_handler(length, context: _ParserContext):
     if length < 2:
-        # A valid field name/value pair is at least two octets: one for the field name SID and one for the value.
         raise IonException('Ordered structs (type ID 0xD1) must have at least one field name/value pair.')
-    yield ctx.immediate_transition(handler(length, ctx))
+    return IonEvent(IonEventType.CONTAINER_START, IonType.STRUCT, value=length, depth=context.depth), context.buffer
 
 
-@coroutine
-def _container_start_handler(ion_type, length, ctx):
-    """Handles container delegation."""
-    _, self = yield
-
-    container_ctx = ctx.derive_container_context(length)
-    if ctx.annotations and ctx.limit != container_ctx.limit:
-        # 'ctx' is the annotation wrapper context. `container_ctx` represents the wrapper's 'value' subfield. Their
-        # limits must match.
-        raise IonException('Incorrect annotation wrapper length.')
-    delegate = _container_handler(ion_type, container_ctx)
-
-    # We start the container, and transition to the new container processor.
-    yield ctx.event_transition(
-        IonEvent, IonEventType.CONTAINER_START, ion_type, value=None, whence=delegate
-    )
+def _container_start_handler(ion_type, length, context: _ParserContext):
+    # todo: consider extension event to smuggle limit out!
+    return IonEvent(IonEventType.CONTAINER_START, ion_type, value=length, depth=context.depth), context.buffer
 
 
-@coroutine
-def _container_handler(ion_type, ctx):
-    """Handler for the body of a container (or the top-level stream).
-
-    Args:
-        ion_type (Optional[IonType]): The type of the container or ``None`` for the top-level.
-        ctx (_HandlerContext): The context for the container.
+def _ivm_parser(context: _ParserContext):
     """
-    transition = None
-    first = True
-    at_top = ctx.depth == 0
+    Parse and verify an IVM; used only at start of stream.
+    """
+    (buffer, depth) = context[0:3]
+    (type_octet, buffer) = buffer.read_byte()
+    if type_octet != _IVM_START_OCTET:
+        raise IonException(
+            f'Expected binary version marker, got: {bytes(type_octet)}')
+
+    return _ivm_handler(_ParserContext(buffer, depth))
+
+
+def _tlv_parser(context: _ParserContext):
+    """
+    Parse any acceptable top-level or sequence value.
+
+    Validation that IVMs are only at the top-level is in the _ivm_handler.
+    """
+    (buffer, depth) = context
+    (tid, buffer) = buffer.read_byte()
+    return _HANDLER_DISPATCH_TABLE[tid](_ParserContext(buffer, depth))
+
+
+def _struct_item_parser(context: _ParserContext):
+    """
+    Parse the field and value for an item in a struct.
+    """
+    (buffer, depth) = context
+    field_sid, buffer = _var_uint_field_parser(buffer)
+    event, buffer = _tlv_parser(_ParserContext(buffer, depth))
+
+    if not event:
+        return event, buffer
+    else:
+        return event.derive_field_name(SymbolToken(None, field_sid)), buffer
+
+
+class _ContextFrame(NamedTuple):
+    parser: Callable[[_ParserContext], Tuple[IonEvent, SliceableBuffer]]
+    ion_type: Optional[IonType]
+    depth: int
+    limit: int
+
+
+@coroutine
+def stream_handler():
+    """
+    Handler for an Ion Binary value-stream.
+    """
+    buffer = SliceableBuffer.empty()
+    # top-level context limit is -1 to denote no limit
+    context_stack = deque([_ContextFrame(_tlv_parser, None, 0, -1)])
+    cursor = 0
+    ion_event = None
+    skip_or_next = ReadEventType.NEXT
+    expect_data = False
+    # will get swapped out for tlv or struct parser in main loop
+    parser = _ivm_parser
+    parent_type = None
+    depth = 0
+    limit = -1
+
+    # This is the main event loop for the parser coroutine.
+    #
+    # Each iteration begins with responding with previous ion_event (None to start)
+    # and receiving the user's read event.
+    #
+    # Then there are two main parts:
+    # 1/ handles the users' request, checking invariants and extending the
+    #    buffer and/or skipping.
+    # 2/ parses if possible then mutates state based on the results of parsing.
+    #
+    # You should think of them as distinct functions, inlined to avoid stack
+    # push/pop overhead.
     while True:
-        data_event, self = (yield transition)
-        if data_event is not None and data_event.type is ReadEventType.SKIP:
-            yield ctx.read_data_transition(ctx.remaining, self, skip=True)
+        read_event = yield ion_event
+        assert read_event is not None
 
-        if ctx.queue.position == ctx.limit:
-            # We are at the end of the container.
-            # Yield the close event and go to enclosing container.
-            yield Transition(
-                IonEvent(IonEventType.CONTAINER_END, ion_type, depth=ctx.depth-1),
-                ctx.whence
-            )
-
-        if ion_type is IonType.STRUCT:
-            # Read the field name.
-            self_handler = _create_delegate_handler(self)
-            (field_sid, _), _ = yield ctx.immediate_transition(
-                _var_uint_field_handler(self_handler, ctx)
-            )
-            field_name = SymbolToken(None, field_sid)
+        # part 1: handle user's read event
+        if expect_data:
+            if read_event.type is not ReadEventType.DATA:
+                raise TypeError("Data expected!")
+            buffer = buffer.extend(read_event.data)
         else:
-            field_name = None
+            if read_event.type is ReadEventType.DATA:
+                raise TypeError("Next or Skip expected!")
+            skip_or_next = read_event.type
 
-        expects_ivm = first and at_top
-        transition = ctx.immediate_transition(
-            _start_type_handler(field_name, self, ctx, expects_ivm, at_top=at_top)
-        )
-        first = False
+        ion_event = None
+        if skip_or_next is ReadEventType.SKIP:
+            if parent_type is None:
+                raise TypeError("Cannot Skip Top-level values!")
+
+            to_skip = limit - cursor
+            (skipped, buffer) = buffer.skip(to_skip)
+            cursor += skipped
+            if cursor < limit:
+                ion_event = ION_STREAM_INCOMPLETE_EVENT
+
+        # part 2: parse and reset state
+
+        # loop is to consume but suppress nop padding
+        while not ion_event:
+            # we might be at end of container
+            if cursor == limit:
+                ion_event = IonEvent(
+                    IonEventType.CONTAINER_END,
+                    parent_type,
+                    depth=depth - 1)
+            # parsing is fun, let's do that!
+            else:
+                try:
+                    (ion_event, new_buff) = parser(_ParserContext(buffer, depth))
+                    cursor += buffer.size - new_buff.size
+                    buffer = new_buff
+                    if 0 < limit < cursor:
+                        raise IonException("Passed limit of current container!")
+                except IncompleteReadError:
+                    if depth == 0 and buffer.size == 0:
+                        ion_event = ION_STREAM_END_EVENT
+                    else:
+                        ion_event = ION_STREAM_INCOMPLETE_EVENT
+
+        event_type = ion_event.event_type
+        if event_type.is_stream_signal:
+            expect_data = True
+        else:
+            expect_data = False
+
+            if event_type is IonEventType.CONTAINER_START:
+                if ion_event.ion_type is IonType.STRUCT:
+                    parser = _struct_item_parser
+                else:
+                    parser = _tlv_parser
+                # we're appropriating "value" for the length of the container
+                frame = _ContextFrame(parser, ion_event.ion_type, depth + 1, cursor + ion_event.value)
+                context_stack.append(frame)
+                ion_event = ion_event.derive_value(None)
+            elif event_type is IonEventType.CONTAINER_END:
+                context_stack.pop()
+
+            (parser, parent_type, depth, limit) = context_stack[-1]
 
 
 #
@@ -735,7 +604,7 @@ def _symbol_factory(data):
 
 
 def _string_factory(data):
-    return lambda: data.decode('utf-8')
+    return lambda: str(data, 'utf-8')
 
 
 def _lob_factory(data):
@@ -748,14 +617,9 @@ def _lob_factory(data):
 #
 
 
-# Handler table for type octet to handler co-routine.
-_HANDLER_DISPATCH_TABLE = [None] * 256
-
-
-def _bind_invalid_handlers():
-    """Seeds the co-routine table with all invalid handlers."""
-    for type_octet in range(256):
-        _HANDLER_DISPATCH_TABLE[type_octet] = partial(_invalid_handler, type_octet)
+# Handler table for type octet to handler co-routine, initialized with the
+# invalid handler for all octets.
+_HANDLER_DISPATCH_TABLE: List[Callable] = [partial(_invalid_handler, i) for i in range(256)]
 
 
 def _bind_null_handlers():
@@ -785,7 +649,7 @@ def _bind_length_handlers(tids, user_handler, lns):
             type_octet = _gen_type_octet(tid, ln)
             ion_type = _TID_VALUE_TYPE_TABLE[tid]
             if ln == 1 and ion_type is IonType.STRUCT:
-                handler = partial(_ordered_struct_start_handler, partial(user_handler, ion_type))
+                handler = partial(_var_uint_field_handler, _ordered_struct_start_handler)
             elif ln < _LENGTH_FIELD_FOLLOWS:
                 # Directly partially bind length.
                 handler = partial(user_handler, ion_type, ln)
@@ -808,8 +672,6 @@ def _bind_length_scalar_handlers(tids, scalar_factory, lns=_NON_ZERO_LENGTH_LNS)
     handler = partial(_length_scalar_handler, scalar_factory)
     return _bind_length_handlers(tids, handler, lns)
 
-# First seed all type byte handlers with invalid.
-_bind_invalid_handlers()
 
 # Populate the actual handlers.
 _HANDLER_DISPATCH_TABLE[_IVM_START_OCTET] = _ivm_handler
@@ -830,39 +692,4 @@ _bind_length_handlers([_TypeID.NULL], _nop_pad_handler, _ALL_LENGTH_LNS)
 # Make immutable.
 _HANDLER_DISPATCH_TABLE = tuple(_HANDLER_DISPATCH_TABLE)
 
-
-def raw_reader(queue=None):
-    """Returns a raw binary reader co-routine.
-
-    Args:
-        queue (Optional[BufferQueue]): The buffer read data for parsing, if ``None`` a
-            new one will be created.
-
-    Yields:
-        IonEvent: parse events, will have an event type of ``INCOMPLETE`` if data is needed
-            in the middle of a value or ``STREAM_END`` if there is no data **and** the parser
-            is not in the middle of parsing a value.
-
-            Receives :class:`DataEvent`, with :class:`ReadEventType` of ``NEXT`` or ``SKIP``
-            to iterate over values, or ``DATA`` if the last event was a ``INCOMPLETE``
-            or ``STREAM_END`` event type.
-
-            ``SKIP`` is only allowed within a container. A reader is *in* a container
-            when the ``CONTAINER_START`` event type is encountered and *not in* a container
-            when the ``CONTAINER_END`` event type for that container is encountered.
-    """
-    if queue is None:
-        queue = BufferQueue()
-    ctx = _HandlerContext(
-        position=0,
-        limit=None,
-        queue=queue,
-        field_name=None,
-        annotations=None,
-        depth=0,
-        whence=None
-    )
-
-    return reader_trampoline(_container_handler(None, ctx))
-
-binary_reader = raw_reader
+binary_reader = stream_handler

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -416,17 +416,17 @@ def stream_handler():
         # part 1: handle user's read event
         if expect_data:
             if read_event.type is not ReadEventType.DATA:
-                raise TypeError("Data expected!")
+                raise TypeError("Data expected")
             buffer = buffer.extend(read_event.data)
         else:
             if read_event.type is ReadEventType.DATA:
-                raise TypeError("Next or Skip expected!")
+                raise TypeError("Next or Skip expected")
             skip_or_next = read_event.type
 
         ion_event = None
         if skip_or_next is ReadEventType.SKIP:
             if parent_type is None:
-                raise TypeError("Cannot Skip Top-level values!")
+                raise TypeError("Skip is only allowed within an Ion Container (Struct, List, S-expression)")
 
             to_skip = limit - cursor
             (skipped, buffer) = buffer.skip(to_skip)

--- a/amazon/ion/sliceable_buffer.py
+++ b/amazon/ion/sliceable_buffer.py
@@ -1,0 +1,164 @@
+from typing import NamedTuple, List
+
+
+class SliceableBuffer:
+    """
+    A theoretically infinite immutable buffer from which readers may read bytes
+    or slices by position.
+
+    Reads return the data and a new buffer starting at the end of the read.
+    As the reader advances past chunks (either through reads or skips), whole
+    chunks are dropped from the buffer.
+
+    Built with the assumption that chunks will be reasonably large and that
+    relatively few (single digit) chunks will be buffered at once.
+    """
+
+    @staticmethod
+    def empty():
+        """
+        Create a new buffer with no data.
+        """
+        return SliceableBuffer([])
+
+    def __init__(self, chunks, offset=0, size=0):
+        """
+        *Class internal usage only.*
+
+        Users should use `empty()` to get a new buffer.
+        """
+        self._chunks: List[_ChunkPair] = chunks
+        # the offset adds complexity but enables keeping and dropping of whole
+        # chunks which is more efficient than slicing and copying the chunks
+        # on each read or skip.
+        self._offset = offset
+        self.size = size
+
+    def extend(self, chunk):
+        """
+        Return a new buffer with the chunk appended.
+        """
+        if not chunk:
+            raise ValueError("Chunk must be not None and non-empty!")
+
+        mem_chunk = memoryview(chunk)
+        pair = _ChunkPair(mem_chunk, len(mem_chunk))
+        return SliceableBuffer(
+            self._chunks + [pair],
+            self._offset,
+            self.size + pair.length)
+
+    def read_byte(self):
+        """
+        Read the next byte from the buffer, return (byte, new buffer).
+
+        Raise IncompleteReadError if the buffer is empty.
+        """
+        size = self.size
+        chunks = self._chunks
+        offset = self._offset
+
+        try:
+            # assume that we have data, and that chunks are non-empty
+            (chunk, length) = chunks[0]
+        except IndexError:
+            raise IncompleteReadError("Buffer is empty!")
+
+        if length == offset + 1:
+            return chunk[offset], SliceableBuffer(chunks[1:], 0, size - 1)
+        else:
+            return chunk[offset], SliceableBuffer(chunks, offset + 1, size - 1),
+
+    def read_slice(self, n):
+        """
+        Read a slice of the buffer, return (slice, new buffer).
+
+        Raise IncompleteReadError if the slice cannot be fully read.
+
+        Chunks which are no longer readable are dropped from the new buffer.
+        Bytes are only copied if the read requires bridging chunks.
+        """
+        size = self.size
+        chunks = self._chunks
+        offset = self._offset
+        endpos = offset + n
+
+        if size < n:
+            raise IncompleteReadError(f'Buffer has size {size}, but {n} bytes were requested!')
+
+        # short-circuit when we can serve full read from first chunk
+        # optimizes for common case and simplifies accumulation loop
+        (chunk, length) = chunks[0]
+        if endpos < length:
+            return chunk[offset:endpos], SliceableBuffer(chunks, offset + n, size - n)
+        elif endpos == length:
+            return chunk[offset:], SliceableBuffer(chunks[1:], 0, size - n)
+
+        slices = [_ChunkPair(chunk[offset:], length - offset)]
+
+        # remaining and i are used to init the new buffer after the loop
+        remaining = endpos - length
+        i = 1
+        for (i, pair) in enumerate(chunks[1:], start=1):
+            (chunk, length) = pair
+            if remaining < length:
+                slices.append(_ChunkPair(chunk[:remaining], remaining))
+                break
+
+            slices.append(pair)
+            remaining -= length
+            if remaining == 0:
+                # move i forward to drop the chunk in the new buffer
+                i += 1
+                break
+
+        combined = bytearray(n)
+        cursor = 0
+        for (chunk, length) in slices:
+            combined[cursor:cursor + length] = chunk
+            cursor += length
+
+        return memoryview(combined), SliceableBuffer(chunks[i:], remaining, size - n)
+
+    def skip(self, n):
+        """
+        Skip max(n, size) bytes, return (skipped, new buffer).
+
+        Chunks which are no longer readable are dropped from the new buffer.
+        """
+        size = self.size
+        chunks = self._chunks
+        offset = self._offset
+        endpos = offset + n
+
+        if size <= n:
+            return size, SliceableBuffer([])
+
+        remaining = endpos
+        i = 0
+        for (i, (_, length)) in enumerate(chunks):
+            if remaining < length:
+                break
+
+            remaining -= length
+            if remaining == 0:
+                # move i forward to drop the chunk in the new buffer
+                i += 1
+                break
+
+        return n, SliceableBuffer(chunks[i:], remaining, size - n)
+
+    def __len__(self):
+        """
+        Length of data in bytes remaining in buffer.
+        """
+        return self.size
+
+
+class IncompleteReadError(IndexError):
+    pass
+
+
+class _ChunkPair(NamedTuple):
+    chunk: memoryview
+    length: int

--- a/amazon/ion/sliceable_buffer.py
+++ b/amazon/ion/sliceable_buffer.py
@@ -81,6 +81,9 @@ class SliceableBuffer:
         size = self.size
         chunks = self._chunks
         offset = self._offset
+        if n < 1:
+            raise ValueError("n must be >= 1")
+
         endpos = offset + n
 
         if size < n:

--- a/amazon/ion/sliceable_buffer.py
+++ b/amazon/ion/sliceable_buffer.py
@@ -125,6 +125,9 @@ class SliceableBuffer:
         Skip max(n, size) bytes, return (skipped, new buffer).
 
         Chunks which are no longer readable are dropped from the new buffer.
+
+        Unlike the read methods, skip allows partial skipping, which is more
+        memory efficient when skipping large tokens that span chunks.
         """
         size = self.size
         chunks = self._chunks

--- a/tests/test_sliceable_buffer.py
+++ b/tests/test_sliceable_buffer.py
@@ -1,0 +1,200 @@
+from typing import NamedTuple, Sequence, Callable
+
+from _pytest.python_api import raises
+
+from amazon.ion.sliceable_buffer import IncompleteReadError, SliceableBuffer
+from tests import parametrize
+
+"""
+This test rips off the pattern from test_reader_buffer and the relevant
+(for now) tests.
+
+The SliceableBuffer is not intended as a drop-in replacement for the
+BufferQueue so there are just enough differences to warrant copying and 
+modifying vs re-using as-is.
+
+The intention/hope is that eventually that buffer will be replaced by this
+one and then this will be the only remaining test.
+"""
+
+
+def read(expected):
+    def action(buffer):
+        read_len = len(expected)
+        (actual, buffer) = buffer.read_slice(read_len)
+        assert actual == expected
+
+        return -read_len, buffer
+
+    return action
+
+
+def expect(exception, action):
+    def raises_action(buffer):
+        with raises(exception):
+            action(buffer)
+        return 0, buffer
+
+    return raises_action
+
+
+def extend(data):
+    def action(buffer):
+        return len(data), buffer.extend(data)
+
+    return action
+
+
+def read_byte(expected):
+    def action(buffer):
+        (actual, buffer) = buffer.read_byte()
+        assert expected[0] == actual
+
+        return -1, buffer
+
+    return action
+
+
+def skip(n, expected_rem=0):
+    def action(buffer):
+        (skipped, buffer) = buffer.skip(n)
+        assert expected_rem == n - skipped
+        return -skipped, buffer
+
+    return action
+
+
+class _P(NamedTuple):
+    desc: str
+    actions: Sequence[Callable]
+    is_unicode: bool = False
+
+    def __str__(self):
+        return self.desc
+
+
+@parametrize(
+    _P(
+        desc='EMPTY READ BYTE',
+        actions=[
+            expect(IncompleteReadError, read_byte(97)),
+        ],
+    ),
+    _P(
+        desc='EMPTY READ SLICE',
+        actions=[
+            expect(IncompleteReadError, read(b'ignored')),
+        ],
+    ),
+    _P(
+        desc='SINGLE FULL',
+        actions=[
+            extend(b'abcd'),
+            read(b'abcd'),
+        ],
+    ),
+    _P(
+        desc='SINGLE BYTE FULL',
+        actions=[
+            extend(b'a'),
+            read_byte(b'a'),
+        ],
+    ),
+    _P(
+        desc='CHOMP CHOMP DONE',
+        actions=[
+            extend(b'ab'),
+            read_byte(b'a'),
+            read_byte(b'b'),
+        ],
+    ),
+    _P(
+        desc='SINGLE SKIP FULL',
+        actions=[
+            extend(b'abcd'),
+            skip(4, expected_rem=0),
+            skip(4, expected_rem=4),
+        ],
+    ),
+    _P(
+        desc='SKIP TWO OF THREE',
+        actions=[
+            extend(b'ab'),
+            extend(b'cd'),
+            extend(b'ef'),
+            skip(4, expected_rem=0),
+            read(b'ef')
+        ],
+    ),
+    _P(
+        desc='SINGLE PART',
+        actions=[
+            extend(b'abcdefg'),
+            read(b'ab'),
+            read_byte(b'c'),
+            skip(2),
+            read(b'fg'),
+        ],
+    ),
+    _P(
+        desc='MULTI PART AND SPAN',
+        actions=[
+            extend(b'abcd'),
+            extend(b'efgh'),
+            read(b'ab'),
+            read(b'cdef'),
+
+            extend(b'ijkl'),
+            read(b'ghij'),
+
+            extend(b'mnop'),
+            read(b'klmnop'),
+
+            extend(b'abcd'),
+            extend(b'efgh'),
+            extend(b'ijkl'),
+            extend(b'm'),
+            read(b'abcdefghi'),
+            read_byte(b'j'),
+            read_byte(b'k'),
+            read_byte(b'l'),
+            read_byte(b'm'),
+        ],
+    ),
+    _P(
+        desc='MULTI MIDDLE',
+        actions=[
+            extend(b'abcdefg'),
+            extend(b'hijklmn'),
+            read(b'ab'),
+            read(b'cdef'),
+            read(b'ghij'),
+            read(b'klm'),
+            read(b'n')
+        ],
+    ),
+    _P(
+        desc='MULTI MIDDLE SKIP',
+        actions=[
+            extend(b'abcdefg'),
+            extend(b'hijklmn'),
+            read(b'ab'),
+            skip(4),
+            read(b'ghij'),
+            skip(3),
+            read(b'n')
+        ],
+    ),
+)
+def test_buffer(p):
+    buffer = SliceableBuffer.empty()
+    expected_len = 0
+
+    for action in p.actions:
+        buffer_len = len(buffer)
+        assert buffer_len == expected_len
+
+        len_change, buffer = action(buffer)
+        expected_len += len_change
+
+    assert len(buffer) == expected_len

--- a/tests/test_sliceable_buffer.py
+++ b/tests/test_sliceable_buffer.py
@@ -77,13 +77,22 @@ class _P(NamedTuple):
     _P(
         desc='EMPTY READ BYTE',
         actions=[
-            expect(IncompleteReadError, read_byte(97)),
+            expect(IncompleteReadError, read_byte(b'a')),
         ],
     ),
     _P(
         desc='EMPTY READ SLICE',
         actions=[
             expect(IncompleteReadError, read(b'ignored')),
+        ],
+    ),
+    _P(
+        desc='INCOMPLETE READ SLICE',
+        actions=[
+            extend(b'abcd'),
+            read_byte(b'a'),
+            expect(IncompleteReadError, read(b'bcde')),
+            read_byte(b'b')
         ],
     ),
     _P(
@@ -114,6 +123,14 @@ class _P(NamedTuple):
             extend(b'abcd'),
             skip(4, expected_rem=0),
             skip(4, expected_rem=4),
+        ],
+    ),
+    _P(
+        desc='PARTIAL SKIP INCOMPLETE',
+        actions=[
+            extend(b'ab'),
+            extend(b'cd'),
+            skip(5, expected_rem=1),
         ],
     ),
     _P(


### PR DESCRIPTION
This commit refactors the pure python (non-extension) binary reader to
improve performance. My testing shows it to be roughly 2.5x faster.

It ditches the coroutine dispatching overhead within the reader and
replaces the stateful buffer with an immutable buffer that uses
memoryviews to decrease memory allocations. The immutability of the
buffer is less important for the binary reader but will be important
for the text reader where we often need to look ahead.

It contains a change to the IonThunkEvent that should have a positive
impact on the text reader as well. More impactful will be to apply
this pattern to the text reader.

I left the managed_reader unchanged though de-coroutining that and
minimizing managed event construction could yield more gains for both
text and binary.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
