### PR TITLE
Warn on ImportError when importing ionc

### DIFF
--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -14,6 +14,7 @@
 
 """Provides a ``simplejson``-like API for dumping and loading Ion data."""
 import io
+import warnings
 from datetime import datetime
 from decimal import Decimal
 from io import BytesIO, TextIOBase
@@ -34,11 +35,14 @@ from .writer_binary import binary_writer
 
 
 # Using C extension as default, and original python implementation if C extension doesn't exist.
-c_ext = True
+c_ext = False
 try:
     import amazon.ion.ionc as ionc
+    c_ext = True
 except ModuleNotFoundError:
-    c_ext = False
+    pass
+except ImportError as e:
+    warnings.warn(f"Failed to load ionc module: {e.msg}", ImportWarning)
 
 _ION_CONTAINER_END_EVENT = IonEvent(IonEventType.CONTAINER_END)
 _IVM = b'\xe0\x01\x00\xea'


### PR DESCRIPTION
Before this change ImportErrors other than ModuleNotFoundErrors would
propagate. Unless a user was catching the importing of the simpleion
module (and why would they?) this would result in their process
crashing. Users may have encountered this in platforms that disallow
c extensions, such as spark, or if they had an ionc dynamic library
that didn't match the architecture of the python runtime.

Now it will warn but import will proceed with pure python mode.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
