### PR TITLE
Bumps version to 0.11.1 and drops the support of Python versions older than 3.7.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8' ]
+        python-version: ['3.8', '3.9', '3.10', 'pypy-3.8']
     steps:
       - uses: actions/checkout@v3
       - name: Set up python

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 ### 0.11.1 (2023-10-09)
-Drops the support for Python versions older than 3.7.
+Drops the support for Python versions older than 3.8.
 
 ### 0.11.0 (2023-10-09)
 * Refactors the benchmark tool

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### 0.11.1 (2023-10-09)
+Drops the support for Python versions older than 3.7.
+
 ### 0.11.0 (2023-10-09)
 * Refactors the benchmark tool
 * Uses specific ion-c version to build ion-python C extension. (#250)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for Python.
 [![Build Status](https://travis-ci.org/amazon-ion/ion-python.svg?branch=master)](https://travis-ci.org/amazon-ion/ion-python)
 [![Documentation Status](https://readthedocs.org/projects/ion-python/badge/?version=latest)](https://ion-python.readthedocs.io/en/latest/?badge=latest)
 
-This package is designed to work with **Python 3.7+**. It is intended to work with all stable minor versions. Newer language features will be used as deemed valuable. Support may be dropped for versions more than six months past EOL. 
+This package is designed to work with **Python 3.8+**. Newer language features will be used as deemed valuable. Support may be dropped for versions more than six months past EOL. 
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for Python.
 [![Build Status](https://travis-ci.org/amazon-ion/ion-python.svg?branch=master)](https://travis-ci.org/amazon-ion/ion-python)
 [![Documentation Status](https://readthedocs.org/projects/ion-python/badge/?version=latest)](https://ion-python.readthedocs.io/en/latest/?badge=latest)
 
-This package is designed to work with **Python 3**. It is intended to work with all stable minor versions. Newer language features will be used as deemed valuable. Support may be dropped for versions more than six months past EOL. 
+This package is designed to work with **Python 3.7+**. It is intended to work with all stable minor versions. Newer language features will be used as deemed valuable. Support may be dropped for versions more than six months past EOL. 
 
 ## Getting Started
 
@@ -81,13 +81,13 @@ installed Python (`requirements.txt` installs `tox`).
 Install relevant versions of Python:
 
 ```
-$ for V in 3.7.10 3.8.10 3.9.5 pypy3.7-7.3.5; do pyenv install $V; done
+$ for V in 3.8.10 3.9.5 do pyenv install $V; done
 ```
 
 Once you have these installations, add them as a local `pyenv` configuration
 
 ```
-$ pyenv local 3.7.10 3.8.10 3.9.5 pypy3.7-7.3.5
+$ pyenv local 3.8.10 3.9.5
 ```
 
 Assuming you have `pyenv` properly set up (making sure `pyenv init` is evaluated into your shell),

--- a/amazon/ion/__init__.py
+++ b/amazon/ion/__init__.py
@@ -12,7 +12,7 @@
 # specific language governing permissions and limitations under the
 # License.
 __author__ = 'Amazon.com, Inc.'
-__version__ = '0.11.0'
+__version__ = '0.11.1'
 
 __all__ = [
     'core',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def run_setup():
 
     setup(
         name='amazon.ion',
-        version='0.11.0',
+        version='0.11.1',
         description='A Python implementation of Amazon Ion.',
         url='http://github.com/amazon-ion/ion-python',
         author='Amazon Ion Team',


### PR DESCRIPTION
Release workflow failed due to below error. This is because python 3.7 doesn't support this module. So in this PR, we bumps the version to 0.11.1 and drop the support of python versions <3.7.
```
tests/test_benchmark_cli.py:9: in <module>
    from amazon.ionbenchmark.ion_benchmark_cli import TOOL_VERSION
amazon/ionbenchmark/ion_benchmark_cli.py:39: in <module>
    from amazon.ionbenchmark.benchmark_runner import run_benchmark
amazon/ionbenchmark/benchmark_runner.py:13: in <module>
    from amazon.ionbenchmark.sample_dist import SampleDist
amazon/ionbenchmark/sample_dist.py:7: in <module>
    _unit_normal = statistics.NormalDist()
E   AttributeError: module 'statistics' has no attribute 'NormalDist'
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
