### PR TITLE
Changes IonPyObjects' constructor to be same as their parents' classes.

### DIFF
--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -100,9 +100,9 @@ class IonPyDecimal(Decimal):
     __qualname__ = 'IonPyDecimal'
     ion_type = IonType.DECIMAL
 
-    def __new__(cls, ion_type=IonType.DECIMAL, value=None, annotations=()):
-        v = super().__new__(cls, value)
-        v.ion_annotations = annotations
+    def __new__(cls, *args, **kwargs):
+        v = super().__new__(cls, *args, **kwargs)
+        v.ion_annotations = ()
         return v
 
     def __copy__(self):
@@ -114,7 +114,7 @@ class IonPyDecimal(Decimal):
 
     @staticmethod
     def _to_constructor_args(value):
-        return (None, value,), {}
+        return (value,), {}
 
     @classmethod
     def from_event(cls, ion_event):
@@ -157,10 +157,10 @@ class IonPyBytes(bytes):
     __name__ = 'IonPyBytes'
     __qualname__ = 'IonPyBytes'
 
-    def __new__(cls, ion_type=IonType.BLOB, value=None, annotations=()):
-        v = super().__new__(cls, value)
-        v.ion_annotations = annotations
-        v.ion_type = ion_type
+    def __new__(cls, *args, **kwargs):
+        v = super().__new__(cls, *args, **kwargs)
+        v.ion_annotations = ()
+        # v.ion_type = ion_type
         return v
 
     def __copy__(self):
@@ -172,7 +172,7 @@ class IonPyBytes(bytes):
 
     @staticmethod
     def _to_constructor_args(value):
-        return (None, value,), {}
+        return (value, ), {}
 
     @classmethod
     def from_event(cls, ion_event):
@@ -216,9 +216,9 @@ class IonPyInt(int):
     __qualname__ = 'IonPyInt'
     ion_type = IonType.INT
 
-    def __new__(cls, ion_type=IonType.INT, value=None, annotations=()):
-        v = super().__new__(cls, value)
-        v.ion_annotations = annotations
+    def __new__(cls, *args, **kwargs):
+        v = super().__new__(cls, *args, **kwargs)
+        v.ion_annotations = ()
         return v
 
     def __copy__(self):
@@ -230,7 +230,7 @@ class IonPyInt(int):
 
     @staticmethod
     def _to_constructor_args(value):
-        return (None, value,), {}
+        return (value, ), {}
 
     @classmethod
     def from_event(cls, ion_event):
@@ -277,9 +277,9 @@ class IonPyBool(int):
     def __repr__(self):
         return str(bool(self))
 
-    def __new__(cls, ion_type=IonType.BOOL, value=None, annotations=()):
-        v = super().__new__(cls, value)
-        v.ion_annotations = annotations
+    def __new__(cls, *args, **kwargs):
+        v = super().__new__(cls, *args, **kwargs)
+        v.ion_annotations = ()
         return v
 
     def __copy__(self):
@@ -291,7 +291,7 @@ class IonPyBool(int):
 
     @staticmethod
     def _to_constructor_args(value):
-        return (None, value,), {}
+        return (value, ), {}
 
     @classmethod
     def from_event(cls, ion_event):
@@ -335,9 +335,9 @@ class IonPyFloat(float):
     __qualname__ = 'IonPyFloat'
     ion_type = IonType.FLOAT
 
-    def __new__(cls, ion_type=IonType.FLOAT, value=None, annotations=()):
-        v = super().__new__(cls, value)
-        v.ion_annotations = annotations
+    def __new__(cls, *args, **kwargs):
+        v = super().__new__(cls, *args, **kwargs)
+        v.ion_annotations = ()
         return v
 
     def __copy__(self):
@@ -349,7 +349,7 @@ class IonPyFloat(float):
 
     @staticmethod
     def _to_constructor_args(value):
-        return (None, value,), {}
+        return (value, ), {}
 
     @classmethod
     def from_event(cls, ion_event):
@@ -393,9 +393,9 @@ class IonPyText(str):
     __qualname__ = 'IonPyText'
     ion_type = IonType.STRING
 
-    def __new__(cls, ion_type=IonType.STRING, value=None, annotations=()):
-        v = super().__new__(cls, value)
-        v.ion_annotations = annotations
+    def __new__(cls, *args, **kwargs):
+        v = super().__new__(cls, *args, **kwargs)
+        v.ion_annotations = ()
         return v
 
     def __copy__(self):
@@ -407,7 +407,7 @@ class IonPyText(str):
 
     @staticmethod
     def _to_constructor_args(value):
-        return (None, value,), {}
+        return (value, ), {}
 
     @classmethod
     def from_event(cls, ion_event):
@@ -452,22 +452,8 @@ class IonPyTimestamp(Timestamp):
     ion_type = IonType.TIMESTAMP
 
     def __new__(cls, *args, **kwargs):
-        # The from_value like signature
-        if isinstance(args[0], IonType):
-            value = args[1]
-            annotations = ()
-            if len(args) > 2 and args[2] is not None:
-                annotations = args[2]
-            if value is not None:
-                args_new, kwargs = cls._to_constructor_args(value)
-            else:
-                args_new, kwargs = (None, None, ()), {}
-            v = super().__new__(cls, *args_new, **kwargs)
-            v.ion_type = args[0]
-            v.ion_annotations = annotations
-        # Regular timestamp constructor
-        else:
-            v = super().__new__(cls, *args, **kwargs)
+        v = super().__new__(cls, *args, **kwargs)
+        v.ion_annotations = ()
         return v
 
     def __copy__(self):
@@ -532,9 +518,9 @@ class IonPySymbol(SymbolToken):
     ion_type = IonType.SYMBOL
 
     # a good signature: IonPySymbol(ion_type, symbol_token, annotation)
-    def __new__(cls, ion_type=IonType.SYMBOL, value=None, annotations=()):
-        v = super().__new__(cls, *value)
-        v.ion_annotations = annotations
+    def __new__(cls, *args, **kwargs):
+        v = super().__new__(cls, *args, **kwargs)
+        v.ion_annotations = ()
         return v
 
     def __copy__(self):
@@ -547,9 +533,9 @@ class IonPySymbol(SymbolToken):
     @staticmethod
     def _to_constructor_args(st):
         try:
-            args = (None, (st.text, st.sid, st.location), ())
+            args = (st.text, st.sid, st.location)
         except AttributeError:
-            args = (None, (st, None, None), ())
+            args = (st, None, None)
         kwargs = {}
         return args, kwargs
 
@@ -594,13 +580,11 @@ class IonPyList(list):
     __name__ = 'IonPyList'
     __qualname__ = 'IonPyList'
 
-    def __init__(self, ion_type=IonType.LIST, value=None, annotations=()):
-        if value is None:
-            value = []
-        super().__init__(value)
-        self.ion_annotations = annotations
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ion_annotations = ()
         # it's possible to be Sexp
-        self.ion_type = ion_type
+        # self.ion_type = ion_type
 
     def __copy__(self):
         args, kwargs = self._to_constructor_args(self)
@@ -611,14 +595,14 @@ class IonPyList(list):
 
     @staticmethod
     def _to_constructor_args(value):
-        return (None, value,), {}
+        return (value, ), {}
 
     @classmethod
     def from_event(cls, ion_event):
         if ion_event.value is not None:
             args, kwargs = cls._to_constructor_args(ion_event.value)
         else:
-            args, kwargs = (None, [], ()), {}
+            args, kwargs = (), {}
         value = cls(*args, **kwargs)
         value.ion_type = ion_event.ion_type
         value.ion_annotations = ion_event.annotations
@@ -663,12 +647,12 @@ class IonPyDict(MutableMapping):
     __qualname__ = 'IonPyDict'
     ion_type = IonType.STRUCT
 
-    def __init__(self, ion_type=IonType.STRUCT, value=None, annotations=()):
+    def __init__(self, *args, **kwargs):
         super().__init__()
-        self.ion_annotations = annotations
+        self.ion_annotations = ()
         self.__store = OrderedDict()
-        if value is not None:
-            for key, value in iter(value.items()):
+        if args is not None and len(args) > 0:
+            for key, value in iter(args[0].items()):
                 if key in self.__store.keys():
                     self.__store[key].append(value)
                 else:
@@ -747,14 +731,14 @@ class IonPyDict(MutableMapping):
 
     @staticmethod
     def _to_constructor_args(value):
-        return (None, value,), {}
+        return (value, ), {}
 
     @classmethod
     def from_event(cls, ion_event):
         if ion_event.value is not None:
             args, kwargs = cls._to_constructor_args(ion_event.value)
         else:
-            args, kwargs = (None, None, ()), {}
+            args, kwargs = (), {}
         value = cls(*args, **kwargs)
         value.ion_type = ion_event.ion_type
         value.ion_annotations = ion_event.annotations

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -582,7 +582,6 @@ class IonPyList(list):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.ion_annotations = ()
-        # it's possible to be Sexp
 
     def __copy__(self):
         args, kwargs = self._to_constructor_args(self)

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -160,7 +160,6 @@ class IonPyBytes(bytes):
     def __new__(cls, *args, **kwargs):
         v = super().__new__(cls, *args, **kwargs)
         v.ion_annotations = ()
-        # v.ion_type = ion_type
         return v
 
     def __copy__(self):
@@ -584,7 +583,6 @@ class IonPyList(list):
         super().__init__(*args, **kwargs)
         self.ion_annotations = ()
         # it's possible to be Sexp
-        # self.ion_type = ion_type
 
     def __copy__(self):
         args, kwargs = self._to_constructor_args(self)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -34,7 +34,7 @@ def _to_event_parameters():
         [loads('$0'), [IonEvent(IonEventType.SCALAR, IonType.SYMBOL, SymbolToken(None, 0), None, (), depth=0)]],
         [loads('{$0: $0}'), [
             IonEvent(IonEventType.CONTAINER_START, IonType.STRUCT, depth=0),
-            IonEvent(IonEventType.SCALAR, IonType.SYMBOL, IonPySymbol(None, (None, 0)), SymbolToken(None, 0), (), depth=1),
+            IonEvent(IonEventType.SCALAR, IonType.SYMBOL, IonPySymbol(None, 0), SymbolToken(None, 0), (), depth=1),
             IonEvent(IonEventType.CONTAINER_END),
         ]],
         [loads('[1, 2, 3, [4, 5, 6], [7, 8, 9]]'), [

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -761,6 +761,6 @@ def test_ion_py_objects_construction(v):
     """These tests are related to the issue https://github.com/amazon-ion/ion-python/issues/297
 
     Note that IonPyTimestamp.from_value sets the default precision and fraction, while the original constructor doesn't.
-    So, we compare if they represent the same instance; in other words, we set timestamps_instants_only to True.
+    So, we compare if they represent the same instant; in other words, we set timestamps_instants_only to True.
     """
     assert True is ion_equals(v[0], v[1], timestamps_instants_only=True)

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -739,3 +739,28 @@ def test_setting_c_ext_flag():
 
     value = loads("{a:1}")
     dumps(value)
+
+
+@parametrize(
+    (IonPyNull(), IonPyNull.from_value(IonType.NULL, None, ())),
+    (IonPyDecimal(5.6), IonPyDecimal.from_value(IonType.DECIMAL, 5.6, ())),
+    (IonPyBytes(b'asdf'), IonPyBytes.from_value(IonType.CLOB, b'asdf', ())),
+    (IonPyInt(123), IonPyInt.from_value(IonType.INT, 123, ())),
+    (IonPyBool(True), IonPyBool.from_value(IonType.BOOL, True, ())),
+    (IonPyFloat(5.6), IonPyFloat.from_value(IonType.FLOAT, 5.6, ())),
+    (IonPyText(u'string'), IonPyText.from_value(IonType.STRING, u'string', ())),
+    (IonPyTimestamp(year=1, month=1, day=1, tzinfo=OffsetTZInfo(timedelta(minutes=-1))),
+     IonPyTimestamp.from_value(IonType.TIMESTAMP,
+                               datetime(year=1, month=1, day=1, tzinfo=OffsetTZInfo(timedelta(minutes=-1))),
+                               ())),
+    (IonPySymbol(text='symbol', sid=None, location=None), IonPySymbol.from_value(IonType.SYMBOL, 'symbol', ())),
+    (IonPyList([]), IonPyList.from_value(IonType.LIST, [], ())),
+    (IonPyDict({}), IonPyDict.from_value(IonType.STRUCT, {}, ())),
+)
+def test_ion_py_objects_construction(v):
+    """These tests are related to the issue https://github.com/amazon-ion/ion-python/issues/297
+
+    Note that IonPyTimestamp.from_value sets the default precision and fraction, while the original constructor doesn't.
+    So, we compare if they represent the same instance; in other words, we set timestamps_instants_only to True.
+    """
+    assert True is ion_equals(v[0], v[1], timestamps_instants_only=True)

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -760,7 +760,7 @@ def test_setting_c_ext_flag():
 def test_ion_py_objects_construction(v):
     """These tests are related to the issue https://github.com/amazon-ion/ion-python/issues/297
 
-    Note that IonPyTimestamp.from_value sets the default precision and fraction, while the original constructor doesn't.
+    Note that the IonPyTimestamp constructor only sets the attributes for the base datetime type which does not have precision or fractional seconds. IonPyTimestamp.from_value sets these attributes after construction.
     So, we compare if they represent the same instant; in other words, we set timestamps_instants_only to True.
     """
     assert True is ion_equals(v[0], v[1], timestamps_instants_only=True)

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -28,7 +28,7 @@ from amazon.ion import simpleion
 from amazon.ion.exceptions import IonException
 from amazon.ion.symbols import SymbolToken, SYSTEM_SYMBOL_TABLE
 from amazon.ion.writer_binary import _IVM
-from amazon.ion.core import IonType, IonEvent, IonEventType, OffsetTZInfo, Multimap
+from amazon.ion.core import IonType, IonEvent, IonEventType, OffsetTZInfo, Multimap, TimestampPrecision
 from amazon.ion.simple_types import IonPyDict, IonPyText, IonPyList, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, \
     IonPyDecimal, IonPyTimestamp, IonPyBytes, IonPySymbol
 from amazon.ion.equivalence import ion_equals, obj_has_ion_type_and_annotation


### PR DESCRIPTION
### Description:

This PR is working on fixing https://github.com/amazon-ion/ion-python/issues/297. Users use the constructor and `from_value` method to construct Ion values. After the deprecation of IonNature, the constructor of IonPyObjects now have a `from_value`-like signature.

#### Problem statement:
there are a few concerns we have, we need to



In this PR, I allowed both (1) Users should be able to use `from_value` method to construct Ion values.
(2) Users should be able to use IonPyObjects' constructor to construct Ion values, where it's inherited from their parent class (E.g., most of them are native python class such as Int, string)

However, to minimize the risk of breaking existing usage, the C extension return value constructions fall back to using `from_value` method so that IonValues constructions can reuse the existing signature.

### Perf Benchmarking
| name                          |   file_size(B) |   time_min(ns) |   time_mean(ns) |   memory_usage_peak(B) |
|:------------------------------|---------------:|---------------:|----------------:|-----------------------:|
| Before the construction refactor PR |           5208 |     1353876.58 |      1359532.68 |                 475016 |
| Before this PR|           5208 |      935335.43 |       937701.30 |                 365776 |
| After this PR |           5208 |      979675.29 |       989224.61 |                 366144 |

which introduces a 5% perf decrement. (3.5% comparing the original refactor PR)



&nbsp;
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
