### PR TITLE
Uses the latest ion-c version to build C extension

### DIFF
--- a/install.py
+++ b/install.py
@@ -89,9 +89,6 @@ def _download_ionc():
 
         os.chdir(_CURRENT_ION_C_DIR)
 
-        # TODO Use ion-c 1.1.0 for now - https://github.com/amazon-ion/ion-python/issues/249
-        check_call(['git', 'reset', '--hard', 'v1.1.0'])
-
         # Initialize submodule.
         check_call(['git', 'submodule', 'update', '--init'])
 


### PR DESCRIPTION
This PR reverted https://github.com/amazon-ion/ion-python/pull/250 since the issue #249 is solved. 

In details, we do not use a specific ion-c version (v1.1.0) to build C extension anymore. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
