### PR TITLE
Warn on ImportError when importing ionc

### DIFF
--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -14,6 +14,7 @@
 
 """Provides a ``simplejson``-like API for dumping and loading Ion data."""
 import io
+import warnings
 from datetime import datetime
 from decimal import Decimal
 from io import BytesIO, TextIOBase
@@ -37,6 +38,12 @@ try:
     __IS_C_EXTENSION_SUPPORTED = True
 except ModuleNotFoundError:
     __IS_C_EXTENSION_SUPPORTED = False
+except ImportError as e:
+    __IS_C_EXTENSION_SUPPORTED = False
+    warnings.warn(
+        f"Failed to load c-extension module: {e.msg} falling back to pure python implementation",
+        ImportWarning)
+
 # TODO: when we release a new major version, come up with a better way to encapsulate these two variables.
 # __IS_C_EXTENSION_SUPPORTED is a private flag indicating whether the c extension was loaded/is supported.
 # c_ext is a user-facing flag to check whether the c extension is available and/or disable the c extension.


### PR DESCRIPTION
Before this change an ImportError other than ModuleNotFound would
cause an exception to propagate on import that prevented users
from using simpleion at all.

I've seen reports of two different users encountering this error
for two different reasons, and am confident this would fix both.

closes https://github.com/amazon-ion/ion-python/issues/300

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
