### PR TITLE
Simplify ION_DECIMAL to Python Decimal Conversion

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -527,7 +527,6 @@ iERR ionc_write_value(hWRITER writer, PyObject* obj, PyObject* tuple_as_sexp) {
 
         ION_DECIMAL decimal_value;
         IONCHECK(ion_decimal_from_string(&decimal_value, decimal_c_str, &dec_context));
-        // todo: don't we need to also free decimal_c_str?
         Py_DECREF(decimal_str);
 
         IONCHECK(ion_writer_write_ion_decimal(writer, &decimal_value));


### PR DESCRIPTION
This change simplifies the conversion of an ION_DECIMAL to a Python
Decimal when reading Decimals. Instead of converting the ION_DECIMAL
to a tuple of (sign, (digit, ...), exponent) it just gets the string
representation and uses the corresponding Decimal constructor.

This turns out to be about 20% faster for marshalling "bare value"
decimals of reasonable size (think amounts of money) and uses less
memory.

I also removed an unnecessary extra byte padding for int conversion,
removed a superfluous error check and clarified with comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
