### PR TITLE
Emit SymbolTokens for Symbol "bare values"

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -1180,12 +1180,10 @@ iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, BOOL in_s
         }
         case tid_SYMBOL_INT:
         {
-            // Symbols must always be emitted as IonPySymbol, to avoid ambiguity with string.
-            wrap_py_value = TRUE;
             ION_STRING string_value;
             IONCHECK(ion_reader_read_string(hreader, &string_value));
-            ion_nature_constructor = _ionpysymbol_fromvalue;
             py_value = ion_string_to_py_symboltoken(&string_value);
+            ion_nature_constructor = _ionpysymbol_fromvalue;
             break;
         }
         case tid_STRING_INT:

--- a/amazon/ionbenchmark/benchmark_spec.py
+++ b/amazon/ionbenchmark/benchmark_spec.py
@@ -6,8 +6,7 @@ from pathlib import Path
 
 import amazon.ionbenchmark.ion_load_dump as _ion_load_dump
 
-from amazon.ion.simple_types import IonPySymbol
-
+from amazon.ion.symbols import SymbolToken
 
 # Global defaults for CLI test specs
 _tool_defaults = {
@@ -98,7 +97,7 @@ class BenchmarkSpec(dict):
 
         # Convert symbols to strings
         for k in merged.keys():
-            if isinstance(merged[k], IonPySymbol):
+            if isinstance(merged[k], SymbolToken):
                 merged[k] = merged[k].text
 
         # If not an absolute path, make relative to the working directory.

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -718,7 +718,7 @@ def test_loads_unicode_utf8_conversion():
     ("1.2", Decimal, Decimal("1.2")),
     ("2020-08-01T01:05:00-00:00", Timestamp, Timestamp(2020, 8, 1, 1, 5, 0, precision=TimestampPrecision.SECOND)),
     ('"bar"', str, "bar"),
-    ("bar", IonPySymbol, IonPySymbol("bar", None, None)),
+    ("bar", SymbolToken, SymbolToken("bar", None, None)),
     ('{{ "foo" }}', IonPyBytes, lambda x: x.ion_type == IonType.CLOB),
     ("[]", list, []),
     # regression test for sexp suppressing bare_values for children


### PR DESCRIPTION
This change makes it so that Symbols are emitted as Symbol Tokens when
`emit_bare_values` is true. This gets most of the associated
performance gains for Symbols while still avoiding any type ambiguity
between Symbols and Strings.

Since IonPySymbol inherits from SymbolToken users may still check if
and act on a value being a Symbol with a single type check regardless
of "bare-ness." I changed the benchmark spec because it broke in my
own testing.

The flag is still not exposed to users so it shouldn't change anyone's
experience.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
