### PR TITLE
Remove PyObject_HasAttrString condition check.

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -564,10 +564,7 @@ iERR ionc_write_value(hWRITER writer, PyObject* obj, PyObject* tuple_as_sexp) {
         short precision, fractional_precision;
         int final_fractional_precision, final_fractional_seconds;
         precision_attr = PyObject_GetAttrString(obj, "precision");
-        if (precision_attr == NULL) {
-            PyErr_Clear();
-        }
-        else if (precision_attr != Py_None) {
+        if (precision_attr != NULL && precision_attr != Py_None) {
             // This is a Timestamp.
             precision = int_attr_by_name(obj, "precision");
             fractional_precision = int_attr_by_name(obj, "fractional_precision");
@@ -597,7 +594,7 @@ iERR ionc_write_value(hWRITER writer, PyObject* obj, PyObject* tuple_as_sexp) {
                 Py_DECREF(fractional_decimal_tuple);
                 Py_DECREF(py_exponent);
                 Py_DECREF(py_digits);
-
+                Py_DECREF(precision_attr);
             } else {
                 PyErr_Clear();
                 final_fractional_precision = fractional_precision;
@@ -605,6 +602,7 @@ iERR ionc_write_value(hWRITER writer, PyObject* obj, PyObject* tuple_as_sexp) {
             }
         }
         else {
+            PyErr_Clear();
             // This is a naive datetime. It always has maximum precision.
             precision = SECOND_PRECISION;
             final_fractional_precision = MICROSECOND_DIGITS;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
In this PR, we have eliminated the `PyObject_HasAttrString` condition check because the `PyObject_GetAttrString` function  itself checks whether the attribute exists and will return NULL if it doesn't. If the `PyObject_GetAttrString` returns `NULL`, this indicates that an error has occurred, and we will handle the `AttributeError` under this condition.

Here is the benchmark results from benchmarking ion-python (C extension enabled) using shorthand log data.
There is 21.23% performance improvement (`time_mean`) on shorthand log data and 3.35% performance improvement(`time_mean`) on single nested test data.

**`ion-python-benchmark-cli` usage pattern to reproduce the benchmark results:**
` python ion_benchmark_cli.py write --iterations 30 --warmups 10 --io-type file test_data.ion --format ion_binary`

**shorthand log**
|             |   file_size(B) |   time_min(ns) |   time_mean(ns) |   memory_usage_peak(B) |
|:------------------------------------------|---------------:|---------------:|----------------:|-----------------------:|
| Before |       21270622 |  3739596533.40 |   3798220835.84 |               42668611 |
| After |       21270622 |  2950278533.40 |   2991548144.17 |               42616337 |

**single nested**
|              |   file_size(B) |   time_min(ns) |   time_mean(ns) |   memory_usage_peak(B) |
|:-----------------------------|---------------:|---------------:|----------------:|-----------------------:|
| Before |            795 |      197943.52 |       204293.10 |                  35887 |
| After |            795 |      193288.23 |       197446.85 |                  29246 |

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
