### PR TITLE
Try to read and convert Ion INT as int 64

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -1118,21 +1118,29 @@ iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, BOOL in_s
         }
         case tid_INT_INT:
         {
-            ION_INT ion_int_value;
-            IONCHECK(ion_int_init(&ion_int_value, hreader));
-            IONCHECK(ion_reader_read_ion_int(hreader, &ion_int_value));
-            SIZE int_char_len, int_char_written;
-            // ion_int_char_length includes 1 char for \0
-            // which ion_int_to_char sets at end.
-            IONCHECK(ion_int_char_length(&ion_int_value, &int_char_len));
-            char* ion_int_str = (char*)PyMem_Malloc(int_char_len);
-            err = ion_int_to_char(&ion_int_value, (BYTE*)ion_int_str, int_char_len, &int_char_written);
-            if (err) {
+            int64_t int64_value;
+            err = ion_reader_read_int64(hreader, &int64_value);
+            if (err == IERR_OK) {
+                py_value = PyLong_FromLongLong(int64_value);
+            } else if (err == IERR_NUMERIC_OVERFLOW) {
+                ION_INT ion_int_value;
+                IONCHECK(ion_int_init(&ion_int_value, hreader));
+                IONCHECK(ion_reader_read_ion_int(hreader, &ion_int_value));
+                SIZE int_char_len, int_char_written;
+                // ion_int_char_length includes 1 char for \0
+                // which ion_int_to_char sets at end.
+                IONCHECK(ion_int_char_length(&ion_int_value, &int_char_len));
+                char* ion_int_str = (char*)PyMem_Malloc(int_char_len);
+                err = ion_int_to_char(&ion_int_value, (BYTE*)ion_int_str, int_char_len, &int_char_written);
+                if (err) {
+                    PyMem_Free(ion_int_str);
+                    IONCHECK(err);
+                }
+                py_value = PyLong_FromString(ion_int_str, NULL, 10);
                 PyMem_Free(ion_int_str);
-                IONCHECK(err);
+            } else {
+                FAILWITH(err)
             }
-            py_value = PyLong_FromString(ion_int_str, NULL, 10);
-            PyMem_Free(ion_int_str);
 
             ion_nature_constructor = _ionpyint_fromvalue;
             break;


### PR DESCRIPTION
This change makes it so that we try to read Ion INTs as int64s and
convert them to Python with PyLong_FromLongLong. If the int is too
large then we fallback to converting via base 10 string repr.

I don't like adding complexity but this is significantly faster for
datasets with small ints. For example, the "service_log_legacy"
benchmark is about 7% faster with this change.

**Note for Reviewers:**
I looked at other options for efficiently creating PyLongs (all Python
ints are actually "Longs" in Python 3) from Ion INTs. The highest 
"bandwith" way to do arbitrary size ints is getting them as two's 
complement byte arrays. Unfortunately there is no Python C API
call for that, so you need to go through the Object Call protocol
which adds a lot of overhead. There is no existing hex or base 32
char array export that we could give to PyLong_FromString. Even if
there were that path still requires allocations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
