### PR TITLE
Enhance ionc_write_big_int method for optimized handling of large integers.

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -427,7 +427,7 @@ static iERR ionc_write_big_int(hWRITER writer, PyObject *obj) {
     if (!overflow && PyErr_Occurred() == NULL) {
         // Value fits within int64, write it as int64
         IONCHECK(ion_writer_write_int64(writer, int_value));
-    } else{
+    } else {
         PyErr_Clear();
         int_str = PyObject_Str(obj);
         ION_STRING string_value;


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The updated method `ionc_write_big_int` initially attempts to convert the Python object to a C` long long` using `PyLong_AsLongLongAndOverflow`.  If the integer fits within a 64-bit range and no error occurs, it proceeds to write the integer directly using `ion_writer_write_int64`. For integers larger than 64-bit, it will fallback to string conversion. This PR also replaced method `PyObject_CallMethod(obj, "__str__", NULL)` with `PyObject_Str(obj)`, this also improve the performance. 

Here are the benchmark results from benchmarking ion-python writing using service_log_legacy: There is **_14.74%_** performance improvement from the change.

|                                      |   file_size(B) |   time_min(ns) |   time_mean(ns) |   memory_usage_peak(B) |
|:------------------------------------------|---------------:|---------------:|----------------:|-----------------------:|
| Before |       21270622 |  2943214116.60 |   3002532105.01 |               42637008 |
| After |       21270622 |  2520604525.00 |   2559838239.71 |               42647684 |



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
