### PR TITLE
Added and Plumbed IonPyValueModel Flags

### DIFF
--- a/amazon/ion/_ioncmodule.h
+++ b/amazon/ion/_ioncmodule.h
@@ -8,8 +8,8 @@
 PyObject* ionc_init_module(void);
 iERR ionc_write_value(hWRITER writer, PyObject* obj, PyObject* tuple_as_sexp);
 PyObject* ionc_read(PyObject* self, PyObject *args, PyObject *kwds);
-iERR ionc_read_all(hREADER hreader, PyObject* container, BOOL in_struct, int value_model);
-iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, BOOL in_struct, int value_model);
+iERR ionc_read_all(hREADER hreader, PyObject* container, BOOL in_struct, uint8_t value_model);
+iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, BOOL in_struct, uint8_t value_model);
 
 iERR _ion_writer_write_symbol_id_helper(ION_WRITER *pwriter, SID value);
 iERR _ion_writer_add_annotation_sid_helper(ION_WRITER *pwriter, SID sid);

--- a/amazon/ion/_ioncmodule.h
+++ b/amazon/ion/_ioncmodule.h
@@ -8,8 +8,8 @@
 PyObject* ionc_init_module(void);
 iERR ionc_write_value(hWRITER writer, PyObject* obj, PyObject* tuple_as_sexp);
 PyObject* ionc_read(PyObject* self, PyObject *args, PyObject *kwds);
-iERR ionc_read_all(hREADER hreader, PyObject* container, BOOL in_struct, BOOL emit_bare_values);
-iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, BOOL in_struct, BOOL emit_bare_values);
+iERR ionc_read_all(hREADER hreader, PyObject* container, BOOL in_struct, int value_model);
+iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, BOOL in_struct, int value_model);
 
 iERR _ion_writer_write_symbol_id_helper(ION_WRITER *pwriter, SID value);
 iERR _ion_writer_add_annotation_sid_helper(ION_WRITER *pwriter, SID sid);

--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -28,7 +28,7 @@ static char _err_msg[ERR_MSG_MAX_LEN];
 #define _FAILWITHMSG(x, msg) { err = x; snprintf(_err_msg, ERR_MSG_MAX_LEN, msg); goto fail; }
 
 #define IONC_BYTES_FORMAT "y#"
-#define IONC_READ_ARGS_FORMAT "OiO"
+#define IONC_READ_ARGS_FORMAT "ObO"
 
 static PyObject* IONC_STREAM_BYTES_READ_SIZE;
 static PyObject* _math_module;
@@ -99,7 +99,7 @@ typedef struct {
     hREADER reader;
     ION_READER_OPTIONS _reader_options;
     BOOL closed;
-    int value_model;
+    uint8_t value_model;
     _ION_READ_STREAM_HANDLE file_handler_state;
 } ionc_read_Iterator;
 
@@ -1023,10 +1023,10 @@ fail:
  *      hreader:  An ion reader
  *      container:  A container that elements are read from
  *      is_struct:  If the container is an ion struct
- *      value_model: Flags to control what types of values are emitted.
+ *      value_model: Flags to control how Ion values map to Python types
  *
  */
-static iERR ionc_read_into_container(hREADER hreader, PyObject* container, BOOL is_struct, int value_model) {
+static iERR ionc_read_into_container(hREADER hreader, PyObject* container, BOOL is_struct, uint8_t value_model) {
     iENTER;
     IONCHECK(ion_reader_step_in(hreader));
     IONCHECK(Py_EnterRecursiveCall(" while reading an Ion container"));
@@ -1070,10 +1070,10 @@ static void ionc_add_to_container(PyObject* pyContainer, PyObject* element, BOOL
  *      hreader:  An ion reader
  *      ION_TYPE:  The ion type of the reading value as an int
  *      in_struct:  If the current state is in a struct
- *      value_model: Flags to control what types of values are emitted.
+ *      value_model: Flags to control how Ion values map to Python types
  *
  */
-iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, BOOL in_struct, int value_model) {
+iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, BOOL in_struct, uint8_t value_model) {
     iENTER;
     BOOL        wrap_py_value = !value_model;
     BOOL        is_null;
@@ -1335,10 +1335,10 @@ fail:
  *      hreader:  An ion reader
  *      container:  A container that elements are read from
  *      in_struct:  If the current state is in a struct
- *      emit_bare_values: Decides if the value needs to be wrapped
+ *      value_model: Flags to control how Ion values map to Python types
  *
  */
-iERR ionc_read_all(hREADER hreader, PyObject* container, BOOL in_struct, int value_model) {
+iERR ionc_read_all(hREADER hreader, PyObject* container, BOOL in_struct, uint8_t value_model) {
     iENTER;
     ION_TYPE t;
     for (;;) {
@@ -1466,7 +1466,7 @@ void ionc_read_iter_dealloc(PyObject *self) {
 PyObject* ionc_read(PyObject* self, PyObject *args, PyObject *kwds) {
     iENTER;
     PyObject *py_file = NULL; // TextIOWrapper
-    int value_model = 0;
+    uint8_t value_model = 0;
     PyObject *text_buffer_size_limit;
     ionc_read_Iterator *iterator = NULL;
     static char *kwlist[] = {"file", "value_model", "text_buffer_size_limit", NULL};

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -33,7 +33,7 @@ from amazon.ion.simple_types import IonPyDict, IonPyText, IonPyList, IonPyNull, 
     IonPyDecimal, IonPyTimestamp, IonPyBytes, IonPySymbol
 from amazon.ion.equivalence import ion_equals, obj_has_ion_type_and_annotation
 from amazon.ion.simpleion import dump, dumps, load, loads, _ion_type, _FROM_ION_TYPE, _FROM_TYPE_TUPLE_AS_SEXP, \
-    _FROM_TYPE
+    _FROM_TYPE, IonPyValueModel
 from amazon.ion.writer_binary_raw import _serialize_symbol, _write_length
 from tests.writer_util import VARUINT_END_BYTE, ION_ENCODED_INT_ZERO, SIMPLE_SCALARS_MAP_BINARY, SIMPLE_SCALARS_MAP_TEXT
 from tests import parametrize
@@ -732,13 +732,31 @@ def test_bare_values(params):
 
     ion_text, expected_type, expectation = params
 
-    value = simpleion.load_extension(StringIO(ion_text), emit_bare_values=True)
+    value = simpleion.load_extension(StringIO(ion_text), value_model=IonPyValueModel.MIXED)
 
-    assert type(value) == expected_type
+    assert type(value) is expected_type
     if callable(expectation):
         expectation(value)
     else:
         assert ion_equals(value, expectation)
+
+
+def test_value_models_flags():
+    # This function only tests c extension
+    if not c_ext:
+        return
+
+    ion_text = "31"
+    value = simpleion.load_extension(StringIO(ion_text), value_model=IonPyValueModel.ION_PY)
+    assert type(value) is IonPyInt
+    value = simpleion.load_extension(StringIO(ion_text), value_model=IonPyValueModel.MIXED)
+    assert type(value) is int
+
+    try:
+        simpleion.load_extension(StringIO(ion_text), value_model=IonPyValueModel.SYMBOL_AS_TEXT)
+        assert False
+    except:
+        pass
 
 
 # See issue https://github.com/amazon-ion/ion-python/issues/232

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -732,7 +732,7 @@ def test_bare_values(params):
 
     ion_text, expected_type, expectation = params
 
-    value = simpleion.load_extension(StringIO(ion_text), value_model=IonPyValueModel.MIXED)
+    value = simpleion.load_extension(StringIO(ion_text), value_model=IonPyValueModel.MAY_BE_BARE)
 
     assert type(value) is expected_type
     if callable(expectation):
@@ -749,7 +749,7 @@ def test_value_models_flags():
     ion_text = "31"
     value = simpleion.load_extension(StringIO(ion_text), value_model=IonPyValueModel.ION_PY)
     assert type(value) is IonPyInt
-    value = simpleion.load_extension(StringIO(ion_text), value_model=IonPyValueModel.MIXED)
+    value = simpleion.load_extension(StringIO(ion_text), value_model=IonPyValueModel.MAY_BE_BARE)
     assert type(value) is int
 
     try:


### PR DESCRIPTION
This change adds an IonPyValueModel IntEnum to allow users to control
how Ion values map to IonPy and/or standard Python types when reading.

As noted previously, emitting "bare" values is significantly faster
than emitting IonPy values. I also added flags to affect how Symbols
and Structs map, though they are not yet supported. Profiling revealed
that using Python std types for these two had the most impact on perf,
aside from Timestamps which we are tackling independently.

My plan is to make these two flags work in the c-extension, evaluate
and go from there.

**Reviewer's Note:**
I put this into CR as-is to get some feedback on the naming and semantics
of the flags. I don't intend to merge any flags exposed to the user that aren't 
implemented, at least in the c-extension.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
