### PR TITLE
Implement Symbol as Text in C-extension

### DIFF
--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -767,6 +767,10 @@ def test_value_model_flags(params):
 
 
 def test_undefined_symbol_text_as_text():
+    # This function only tests c extension
+    if not c_ext:
+        return
+
     ion_text = """
     $ion_symbol_table::{ symbols:[ null ] }
     $10


### PR DESCRIPTION
By default the IonPy value for a Symbol is IonPySymbol and the bare
value is a SymbolToken. With the SYMBOL_AS_TEXT flag set, the IonPy
value for a Symbol is IonPyText, and the bare value is str.

This makes Symbol handling simpler if one only cares about the text
value. It also improves load performance for symbols significantly.

Symbols with undefined text cannot be emitted with this flag set and
will raise exceptions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
