### PR TITLE
Create and Build IonPyList instead of wrapping

### DIFF
--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -633,8 +633,7 @@ class IonPyList(list):
         '''
         **Internal Use Only**
 
-        Expects callers to pass a store object for the data that
-        matches the internal representation.
+        Build an empty IonPyList of the specified ion_type.
         '''
         ipl = IonPyList()
         ipl.ion_type = ion_type

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -628,6 +628,21 @@ class IonPyList(list):
                         annotations=self.ion_annotations, depth=depth)
 
 
+    @staticmethod
+    def _factory(ion_type, annotations=()):
+        '''
+        **Internal Use Only**
+
+        Expects callers to pass a store object for the data that
+        matches the internal representation.
+        '''
+        ipl = IonPyList()
+        ipl.ion_type = ion_type
+        ipl.ion_annotations = annotations
+
+        return ipl
+
+
 class IonPyDict(MutableMapping):
     """
     Dictionary that can hold multiple values for the same key


### PR DESCRIPTION
I realized that when we were wrapping the std list in an IonPyList
we were copying it. Creating the IonPyList and filling it avoids
that and improves load performance, both time and memory usage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
