### PR TITLE
struct as stddict

### DIFF
--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -643,6 +643,27 @@ class IonPyList(list):
         return ipl
 
 
+class IonPyStdDict(dict):
+    """
+    IonPy value for standard Python dicts.
+
+    Each key mapping only keeps a single value, later values overwrite prior ones.
+
+    Ideally, the IonPy type for a Struct would wrap either a std dict or a "core"
+    amazon.ion type, like the Multimap. Unfortunately, that composition adds
+    overhead, so we have two IonPy types.
+    While this would be better named "IonPyDict", and the other "IonPyMultiDict",
+    that predates this and changing it would be a breaking change. So here we are.
+    """
+    __name__ = 'IonPyStdDict'
+    __qualname__ = 'IonPyStdDict'
+    ion_type = IonType.STRUCT
+
+    def __init__(self, annotations=()):
+        super().__init__(self)
+        self.ion_annotations = annotations
+
+
 class IonPyDict(MutableMapping):
     """
     Dictionary that can hold multiple values for the same key
@@ -758,7 +779,7 @@ class IonPyDict(MutableMapping):
         return value
 
     @staticmethod
-    def _factory(store, annotations=()):
+    def _factory(_, store, annotations=()):
         '''
         **Internal Use Only**
 

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -628,6 +628,21 @@ class IonPyList(list):
                         annotations=self.ion_annotations, depth=depth)
 
 
+    @staticmethod
+    def _factory(ion_type, annotations=()):
+        '''
+        **Internal Use Only**
+
+        Expects callers to pass a store object for the data that
+        matches the internal representation.
+        '''
+        ipl = IonPyList()
+        ipl.ion_type = ion_type
+        ipl.ion_annotations = annotations
+
+        return ipl
+
+
 class IonPyDict(MutableMapping):
     """
     Dictionary that can hold multiple values for the same key


### PR DESCRIPTION
- Create and Build IonPyList instead of wrapping
- Implement STRUCT_AS_STD_DICT in C-extension load

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
