### PR TITLE
Implement STRUCT_AS_STD_DICT in C-extension load

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -1286,8 +1286,8 @@ iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, BOOL in_s
                 // there is no non-IonPy multimap so we always wrap
                 wrap_py_value = TRUE;
             } else if (wrap_py_value) {
-                // we construct an empty IonPyStdDict to avoid copying the values when wrapping
-                // or needing to delegate in the class, then further wrapping is needed.
+                // we construct an empty IonPyStdDict and don't wrap later to avoid
+                // copying the values when wrapping or needing to delegate in the impl
                 py_value = PyObject_CallFunctionObjArgs(
                         _ionpystddict_cls,
                         py_annotations,

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -642,6 +642,27 @@ class IonPyList(list):
         return ipl
 
 
+class IonPyStdDict(dict):
+    """
+    IonPy value for standard Python dicts.
+
+    Each key mapping only keeps a single value, later values overwrite prior ones.
+
+    Ideally, the IonPy type for a Struct would wrap either a std dict or a "core"
+    amazon.ion type, like the Multimap. Unfortunately, that composition adds
+    overhead, so we have two IonPy types.
+    While this would be better named "IonPyDict", and the other "IonPyMultiDict",
+    that predates this and changing it would be a breaking change. So here we are.
+    """
+    __name__ = 'IonPyStdDict'
+    __qualname__ = 'IonPyStdDict'
+    ion_type = IonType.STRUCT
+
+    def __init__(self, annotations=()):
+        super().__init__(self)
+        self.ion_annotations = annotations
+
+
 class IonPyDict(MutableMapping):
     """
     Dictionary that can hold multiple values for the same key
@@ -757,7 +778,7 @@ class IonPyDict(MutableMapping):
         return value
 
     @staticmethod
-    def _factory(store, annotations=()):
+    def _factory(_, store, annotations=()):
         '''
         **Internal Use Only**
 


### PR DESCRIPTION
Using a std Python dict is significantly faster. A dataset which is
streams of Structs (incredibly common) can expect gains of around 20%
for load times.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
