### PR TITLE
Build Std Dict without Lists

### DIFF
--- a/amazon/ion/_ioncmodule.h
+++ b/amazon/ion/_ioncmodule.h
@@ -8,8 +8,11 @@
 PyObject* ionc_init_module(void);
 iERR ionc_write_value(hWRITER writer, PyObject* obj, PyObject* tuple_as_sexp);
 PyObject* ionc_read(PyObject* self, PyObject *args, PyObject *kwds);
-iERR ionc_read_all(hREADER hreader, PyObject* container, BOOL in_struct, uint8_t value_model);
-iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, BOOL in_struct, uint8_t value_model);
+
+enum ContainerType { LIST, MULTIMAP, STD_DICT };
+
+iERR ionc_read_all(hREADER hreader, PyObject* container, enum ContainerType parent_type, uint8_t value_model);
+iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, enum ContainerType parent_type, uint8_t value_model);
 
 iERR _ion_writer_write_symbol_id_helper(ION_WRITER *pwriter, SID value);
 iERR _ion_writer_add_annotation_sid_helper(ION_WRITER *pwriter, SID sid);

--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -1024,7 +1024,7 @@ fail:
  *
  *  Args:
  *      hreader:  An ion reader
- *      container: A container that elements are read from
+ *      container: A container that elements are read into
  *      parent_type: Type of container to add to.
  *      value_model: Flags to control how Ion values map to Python types
  *

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -776,6 +776,23 @@ def test_value_model_flags(params):
         assert value.ion_type == expected_ion_type
 
 
+def test_stddict():
+    """Verifies that STRUCT_AS_STD_DICT is consistent with json in keeping
+    only the last of a duplicated field.
+    """
+
+    # This function only tests c extension
+    if not c_ext:
+        return
+
+    ion_text = '{ foo: "bar", foo: "baz" }'
+
+    ionpyvalue = simpleion.load_extension(StringIO(ion_text), value_model=IonPyValueModel.STRUCT_AS_STD_DICT)
+    barevalue = simpleion.load_extension(StringIO(ion_text), value_model=IonPyValueModel.STRUCT_AS_STD_DICT | IonPyValueModel.MAY_BE_BARE)
+
+    assert ionpyvalue["foo"] == barevalue["foo"] == "baz"
+
+
 def test_undefined_symbol_text_as_text():
     # This function only tests c extension
     if not c_ext:


### PR DESCRIPTION
The previous STRUCT_AS_STD_DICT commit still builds a "hashmap of
lists" structure for "std" dicts, which was not intended. It was a
failure to get my WIP/POC code into that PR, which this change remedies.

I added a new test to actually verify the behavior. I kept but did
not add to the existing test_value_model_flags because that has a role
in covering the breadth of the IonPyValueFlags and I didn't want to
overcomplicate that for this Struct specific behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
