### PR TITLE
Plumb IonPyValueModel Flags from Benchmark Spec

### DIFF
--- a/amazon/ionbenchmark/ion_load_dump.py
+++ b/amazon/ionbenchmark/ion_load_dump.py
@@ -12,20 +12,21 @@ class IonLoadDump:
     Results of profiling indicate that this adds a trivial amount of overhead, even for small data. If Ion Python
     performance improves by >1000% from June 2023, then this may need to be re-evaluated.
     """
-    def __init__(self, binary, c_ext=True):
+    def __init__(self, binary, c_ext=True, value_model=ion.IonPyValueModel.ION_PY):
         self._binary = binary
         self._single_value = False
         # Need an explicit check here because if `None` is passed in as an argument, that is different from no argument,
         # and results in an unexpected behavior.
         self._c_ext = c_ext if c_ext is not None else True
+        self.value_model = value_model
 
     def loads(self, s):
         ion.c_ext = self._c_ext
-        return ion.loads(s, single_value=self._single_value)
+        return ion.loads(s, single_value=self._single_value, value_model=self.value_model)
 
     def load(self, fp):
         ion.c_ext = self._c_ext
-        return ion.load(fp, single_value=self._single_value)
+        return ion.load(fp, single_value=self._single_value, value_model=self.value_model)
 
     def dumps(self, obj):
         ion.c_ext = self._c_ext

--- a/tests/test_benchmark_spec.py
+++ b/tests/test_benchmark_spec.py
@@ -1,6 +1,8 @@
 from os.path import abspath, join, dirname
 from pathlib import Path
 
+from amazon.ion.simpleion import IonPyValueModel
+from amazon.ion.symbols import SymbolToken
 from amazon.ionbenchmark.benchmark_spec import BenchmarkSpec
 
 
@@ -49,3 +51,13 @@ def test_defaults_and_overrides_applied_in_correct_order():
     assert spec['b'] == 20
     # From user override
     assert spec['c'] == 3
+
+
+def test_model_flags():
+    spec = BenchmarkSpec({**_minimal_params})
+    ion_loader = spec.get_loader_dumper()
+    assert ion_loader.value_model is IonPyValueModel.ION_PY
+
+    spec = BenchmarkSpec({**_minimal_params, 'model_flags': ["MAY_BE_BARE", SymbolToken("SYMBOL_AS_TEXT", None, None)]})
+    ion_loader = spec.get_loader_dumper()
+    assert ion_loader.value_model is IonPyValueModel.MAY_BE_BARE | IonPyValueModel.SYMBOL_AS_TEXT


### PR DESCRIPTION
This change adds the ability to control the IonPyValueModel used in
benchmarking.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
