### PR TITLE
Optimize type check while writing IonStruct.

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -703,7 +703,7 @@ iERR ionc_write_value(hWRITER writer, PyObject* obj, PyObject* tuple_as_sexp) {
 
         IONCHECK(ion_writer_write_timestamp(writer, &timestamp_value));
     }
-    else if (PyDict_Check(obj) || PyObject_IsInstance(obj, _ionpydict_cls)) {
+    else if (PyDict_Check(obj) || PyObject_TypeCheck(obj, (PyTypeObject *)_ionpydict_cls)) {
         if (ion_type == tid_none_INT) {
             ion_type = tid_STRUCT_INT;
         }


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

This pull request optimizes the type checking logic while writing IonStruct by replacing `PyObject_IsInstance` with `PyObject_TypeCheck`. 
Originally, we use `PyObject_IsInstance` to determine if `obj` is an instance of `_ionpydict_cls` or any of its subclasses. In our use case, we are only interested in checking if `obj` is the type `_ionpydict_cls`, without the need to account for subclasses. This aligns with the behavior of` PyObject_TypeCheck`, which performs a direct comparison against the type of `obj` without considering the inheritance hierarchy, thus avoiding additional overhead.

Here are the benchmark results from benchmarking ion-python writing using service_log_legacy:
There is **_7.8%_** performance improvement from the change.

To reproduce this results, please run:
`python ion_benchmark_cli.py write --iterations 30 --warmups 10 --io-type fileservice_log_legacy.ion --format ion_binary`

|                                      |   file_size(B) |   time_min(ns) |   time_mean(ns) |   memory_usage_peak(B) |
|:------------------------------------------|---------------:|---------------:|----------------:|-----------------------:|
| Before |       21270622 |  1851535616.60 |   1870275582.21 |               42581219 |
| After |       21270622 |  1694934066.60 |   1724220828.07 |               42601668 |


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
