### PR TITLE
Optimize ionc_write_struct

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -381,7 +381,7 @@ fail:
  *      tuple_as_sexp: Decides if a tuple is treated as sexp
  */
 
-static iERR write_key_value(hWRITER writer, PyObject* key, PyObject* val, PyObject* tuple_as_sexp) {
+static iERR write_struct_field(hWRITER writer, PyObject* key, PyObject* val, PyObject* tuple_as_sexp) {
     iERR err;
     if (PyUnicode_Check(key)) {
         ION_STRING field_name;
@@ -395,10 +395,7 @@ static iERR write_key_value(hWRITER writer, PyObject* key, PyObject* val, PyObje
     Py_LeaveRecursiveCall();
     IONCHECK(err);
 
-    return IERR_OK;
-
-    fail:
-    return err;
+    iRETURN;
 }
 
 /*
@@ -416,10 +413,10 @@ static iERR ionc_write_struct(hWRITER writer, PyObject* map, PyObject* tuple_as_
     Py_ssize_t pos = 0, i, list_len;
     if (PyDict_Check(map)) {
         while (PyDict_Next(map, &pos, &key, &val)) {
-            IONCHECK(write_key_value(writer, key, val, tuple_as_sexp));
+            IONCHECK(write_struct_field(writer, key, val, tuple_as_sexp));
         }
     } else {
-        store = PyObject_CallMethod(map, "get_store", NULL);
+        store = PyObject_CallMethod(map, "_get_store", NULL);
         if (store == NULL || !PyDict_Check(store)) {
             IONCHECK(IERR_INVALID_ARG);
             goto fail;
@@ -433,7 +430,7 @@ static iERR ionc_write_struct(hWRITER writer, PyObject* map, PyObject* tuple_as_
             list_len = PyList_Size(val_list);
             for (i = 0; i < list_len; i++) {
                 val = PyList_GetItem(val_list, i); // Borrowed reference
-                IONCHECK(write_key_value(writer, key, val, tuple_as_sexp));
+                IONCHECK(write_struct_field(writer, key, val, tuple_as_sexp));
             }
         }
         Py_DECREF(store);

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -744,6 +744,12 @@ class IonPyDict(MutableMapping):
         """
         return [i for i in self.iteritems()]
 
+    def get_store(self):
+        """
+        Return the store of the IonPyDict.
+        """
+        return self.__store
+
     def __copy__(self):
         args, kwargs = self._to_constructor_args(self)
         value = self.__class__(*args, **kwargs)

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -744,12 +744,6 @@ class IonPyDict(MutableMapping):
         """
         return [i for i in self.iteritems()]
 
-    def _get_store(self):
-        """
-        Return the store of the IonPyDict.
-        """
-        return self.__store
-
     def __copy__(self):
         args, kwargs = self._to_constructor_args(self)
         value = self.__class__(*args, **kwargs)

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -744,7 +744,7 @@ class IonPyDict(MutableMapping):
         """
         return [i for i in self.iteritems()]
 
-    def get_store(self):
+    def _get_store(self):
         """
         Return the store of the IonPyDict.
         """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR optimized the handling of `IonPyDict` objects. In the previous implementation, we converted the `PyObject` map into a `sequence` for iteration. The updated approach introduced in this PR separates the handling into two cases based on the type of the map object:
1. For Python dictionaries: When `map` is a standard Python dictionary, we iterate over it directly using `PyDict_Next`. 
2. For `IonPyDict` objects: In cases where map is an instance of IonPyDict, we now access its `_ _store` attribute. This attribute itself is a Python dictionary. By doing so, we can then use `PyDict_Next` to iterate over __store, similar to how we handle standard Python dictionaries.

This optimization eliminates the need to convert IonPyDict objects into sequences before iteration, leading to a more efficient processing process. 

Here are the benchmark results from benchmarking ion-python writing using service_log_legacy:
 There is **_31.2%_** performance improvement from the change.

To reproduce this results, please run:
`python ion_benchmark_cli.py write --iterations 30 --warmups 10 --io-type fileservice_log_legacy.ion --format ion_binary`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
| name                                      |   file_size(B) |   time_min(ns) |   time_mean(ns) |   memory_usage_peak(B) |
|:------------------------------------------|---------------:|---------------:|----------------:|-----------------------:|
| Before |       21270622 |  1715543333.40 |   1753941142.77 |               42597119 |
| After|       21270622 |  1174766083.40 |   1206556276.95 |               42582427 |
