### PR TITLE
Updates the release workflow to support python 3.11 and MacOS arm64.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', 'pypy-3.8', 'pypy-3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.10']
         os: [ macos-latest, ubuntu-latest ]
       fail-fast: false
     steps:
@@ -21,7 +21,7 @@ jobs:
 
       - name: Create a virtual environment
         run: git submodule init && git submodule update && python3 -m venv ./venv && . venv/bin/activate
-
+      - run: pip install --upgrade setuptools
       - run: pip install -r requirements.txt
       - run: pip install -e .
       - run: py.test
@@ -30,7 +30,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', 'pypy-3.8', 'pypy-3.10' ]
+        python-version: ['3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.10' ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -41,6 +41,7 @@ jobs:
 
       - name: Create a virtual environment
         run: git submodule init && git submodule update && python3 -m venv ./venv && . venv/Scripts/activate
+      - run: pip install --upgrade setuptools
       - run: pip install -r requirements.txt
       - run: pip install -e .
       - run: py.test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,64 +25,64 @@ jobs:
       - run: pip install -e .
       - run: py.test
 
-#  source-distribution:
-#    if: startsWith(github.ref, 'refs/tags/')
-#    name: Source distribution
-#    runs-on: ubuntu-latest
-#    needs: [test]
-#    strategy:
-#      matrix:
-#        python-version: [ '3.10' ]
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: Build sdist
-#        run: python3 setup.py sdist
-#
-#      - name: Upload source to Github
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: source
-#          path: ./dist/amazon.ion-*.tar.gz
-#
-#      - uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          role-skip-session-tagging: true
-#          aws-region: us-west-2
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
-#          role-duration-seconds: 900
-#
-#      - name: Upload source to s3
-#        run: |
-#          zip ion-python-source ./dist/amazon.ion-*.tar.gz
-#          aws s3 mv ion-python-source.zip ${{ secrets.AWS_SOURCE_BUCKET_URL }} --acl bucket-owner-full-control
-#
-#      - name: Install the released source from PYPI
-#        run: |
-#          sleep 300s
-#
-#          for (( i=0; i<3; i++ ))
-#          do
-#            v=""
-#
-#            if ! (pip install --no-binary :all: amazon.ion==${GITHUB_REF##*/v}) then
-#              echo "Unable to install the desired version"
-#              sleep 120s
-#              continue
-#            fi
-#
-#            v=$( pip show amazon.ion | grep Version )
-#            break
-#          done
-#
-#          if [[ $v != "Version: ${GITHUB_REF##*/v}" ]]
-#          then
-#            echo "Exiting because unable to install the new version from PYPI"
-#            exit 1
-#          fi
+  source-distribution:
+    if: startsWith(github.ref, 'refs/tags/')
+    name: Source distribution
+    runs-on: ubuntu-latest
+    needs: [test]
+    strategy:
+      matrix:
+        python-version: [ '3.10' ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build sdist
+        run: python3 setup.py sdist
+
+      - name: Upload source to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: source
+          path: ./dist/amazon.ion-*.tar.gz
+
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-skip-session-tagging: true
+          aws-region: us-west-2
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+          role-duration-seconds: 900
+
+      - name: Upload source to s3
+        run: |
+          zip ion-python-source ./dist/amazon.ion-*.tar.gz
+          aws s3 mv ion-python-source.zip ${{ secrets.AWS_SOURCE_BUCKET_URL }} --acl bucket-owner-full-control
+
+      - name: Install the released source from PYPI
+        run: |
+          sleep 300s
+
+          for (( i=0; i<3; i++ ))
+          do
+            v=""
+
+            if ! (pip install --no-binary :all: amazon.ion==${GITHUB_REF##*/v}) then
+              echo "Unable to install the desired version"
+              sleep 120s
+              continue
+            fi
+
+            v=$( pip show amazon.ion | grep Version )
+            break
+          done
+
+          if [[ $v != "Version: ${GITHUB_REF##*/v}" ]]
+          then
+            echo "Exiting because unable to install the new version from PYPI"
+            exit 1
+          fi
 
   build-wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -138,50 +138,50 @@ jobs:
           name: wheels
           path: ./wheelhouse/*.whl
 
-#  upload-wheels:
-#    name: Upload wheels to S3
-#    runs-on: [ubuntu-latest]
-#    needs: [build-wheels]
-#    steps:
-#      - uses: actions/download-artifact@v2
-#        with:
-#          name: wheels
-#
-#      - uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          role-skip-session-tagging: true
-#          aws-region: us-west-2
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
-#          role-duration-seconds: 900
-#
-#      - name: Upload wheels to s3
-#        run: |
-#          zip ion-python-wheels ./*.whl
-#          aws s3 mv ion-python-wheels.zip ${{ secrets.AWS_WHEELS_BUCKET_URL }} --acl bucket-owner-full-control
-#
-#      - name: Install the released wheels from PYPI
-#        run: |
-#          sleep 300s
-#
-#          for (( i=0; i<3; i++ ))
-#          do
-#            v=""
-#
-#            if ! (pip install --only-binary :all: amazon.ion==${GITHUB_REF##*/v}) then
-#              echo "Unable to install the desired version"
-#              sleep 120s
-#              continue
-#            fi
-#
-#            v=$( pip show amazon.ion | grep Version )
-#            break
-#          done
-#
-#          if [[ $v != "Version: ${GITHUB_REF##*/v}" ]]
-#          then
-#            echo "Exiting because unable to install the new version from PYPI"
-#            exit 1
-#          fi
+  upload-wheels:
+    name: Upload wheels to S3
+    runs-on: [ubuntu-latest]
+    needs: [build-wheels]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-skip-session-tagging: true
+          aws-region: us-west-2
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+          role-duration-seconds: 900
+
+      - name: Upload wheels to s3
+        run: |
+          zip ion-python-wheels ./*.whl
+          aws s3 mv ion-python-wheels.zip ${{ secrets.AWS_WHEELS_BUCKET_URL }} --acl bucket-owner-full-control
+
+      - name: Install the released wheels from PYPI
+        run: |
+          sleep 300s
+
+          for (( i=0; i<3; i++ ))
+          do
+            v=""
+
+            if ! (pip install --only-binary :all: amazon.ion==${GITHUB_REF##*/v}) then
+              echo "Unable to install the desired version"
+              sleep 120s
+              continue
+            fi
+
+            v=$( pip show amazon.ion | grep Version )
+            break
+          done
+
+          if [[ $v != "Version: ${GITHUB_REF##*/v}" ]]
+          then
+            echo "Exiting because unable to install the new version from PYPI"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,11 +107,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.10'
-
       - name: Set up pip and setuptools
         run: |
           pip3 install -U pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
+          # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip for more details.
           - os: macos-latest
             arch: x86_64
             cibw_arch: "x86_64"
@@ -100,9 +101,9 @@ jobs:
             arch: arm64
             cibw_arch: "arm64"
           - os: windows-latest
-            cibw_arch: "auto"
+            cibw_arch: "AMD64"
           - os: ubuntu-latest
-            cibw_arch: "auto aarch64"
+            cibw_arch: "i686 x86_64 aarch64"
 
     steps:
       - uses: actions/checkout@v3
@@ -124,7 +125,7 @@ jobs:
       - name: Build wheels
         run: python3 -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: "pp* *-win32 cp36-* cp37-* cp38-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-*"
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
 
       - name: Upload wheels to Github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8']
     steps:
       - uses: actions/checkout@v3
       - name: Set up python
@@ -20,68 +20,69 @@ jobs:
 
       - name: Create a virtual environment
         run: git submodule init && git submodule update && python3 -m venv ./venv && . venv/bin/activate
+      - run: pip install --upgrade setuptools
       - run: pip install -r requirements.txt
       - run: pip install -e .
       - run: py.test
 
-  source-distribution:
-    if: startsWith(github.ref, 'refs/tags/')
-    name: Source distribution
-    runs-on: ubuntu-latest
-    needs: [test]
-    strategy:
-      matrix:
-        python-version: [ '3.10' ]
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Build sdist
-        run: python3 setup.py sdist
-
-      - name: Upload source to Github
-        uses: actions/upload-artifact@v2
-        with:
-          name: source
-          path: ./dist/amazon.ion-*.tar.gz
-
-      - uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-skip-session-tagging: true
-          aws-region: us-west-2
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
-          role-duration-seconds: 900
-
-      - name: Upload source to s3
-        run: |
-          zip ion-python-source ./dist/amazon.ion-*.tar.gz
-          aws s3 mv ion-python-source.zip ${{ secrets.AWS_SOURCE_BUCKET_URL }} --acl bucket-owner-full-control
-
-      - name: Install the released source from PYPI
-        run: |
-          sleep 300s
-
-          for (( i=0; i<3; i++ ))
-          do
-            v=""
-
-            if ! (pip install --no-binary :all: amazon.ion==${GITHUB_REF##*/v}) then
-              echo "Unable to install the desired version"
-              sleep 120s
-              continue
-            fi
-
-            v=$( pip show amazon.ion | grep Version )
-            break
-          done
-
-          if [[ $v != "Version: ${GITHUB_REF##*/v}" ]]
-          then
-            echo "Exiting because unable to install the new version from PYPI"
-            exit 1
-          fi
+#  source-distribution:
+#    if: startsWith(github.ref, 'refs/tags/')
+#    name: Source distribution
+#    runs-on: ubuntu-latest
+#    needs: [test]
+#    strategy:
+#      matrix:
+#        python-version: [ '3.10' ]
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: Build sdist
+#        run: python3 setup.py sdist
+#
+#      - name: Upload source to Github
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: source
+#          path: ./dist/amazon.ion-*.tar.gz
+#
+#      - uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          role-skip-session-tagging: true
+#          aws-region: us-west-2
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+#          role-duration-seconds: 900
+#
+#      - name: Upload source to s3
+#        run: |
+#          zip ion-python-source ./dist/amazon.ion-*.tar.gz
+#          aws s3 mv ion-python-source.zip ${{ secrets.AWS_SOURCE_BUCKET_URL }} --acl bucket-owner-full-control
+#
+#      - name: Install the released source from PYPI
+#        run: |
+#          sleep 300s
+#
+#          for (( i=0; i<3; i++ ))
+#          do
+#            v=""
+#
+#            if ! (pip install --no-binary :all: amazon.ion==${GITHUB_REF##*/v}) then
+#              echo "Unable to install the desired version"
+#              sleep 120s
+#              continue
+#            fi
+#
+#            v=$( pip show amazon.ion | grep Version )
+#            break
+#          done
+#
+#          if [[ $v != "Version: ${GITHUB_REF##*/v}" ]]
+#          then
+#            echo "Exiting because unable to install the new version from PYPI"
+#            exit 1
+#          fi
 
   build-wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -91,10 +92,25 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [ '3.10']
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        include:
+          - os: macos-latest
+            arch: x86_64
+            cibw_arch: "x86_64"
+          - os: macos-14  # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+            arch: arm64
+            cibw_arch: "arm64"
+          - os: windows-latest
+            cibw_arch: "auto"
+          - os: ubuntu-latest
+            cibw_arch: "auto aarch64"
+
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
 
       - name: Set up pip and setuptools
         run: |
@@ -108,15 +124,13 @@ jobs:
           platforms: all
 
       - name: Install cibuildwheel
-        run: python3 -m pip install cibuildwheel==2.4.0
+        run: python3 -m pip install cibuildwheel==2.16.5
 
       - name: Build wheels
         run: python3 -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: "pp* *-win32"
-          CIBW_ARCHS_WINDOWS: "auto"
-          CIBW_ARCHS_LINUX: "auto aarch64"
-          CIBW_ARCHS_MACOS: "x86_64"
+          CIBW_SKIP: "pp* *-win32 cp36-* cp37-* cp38-*"
+          CIBW_ARCHS: ${{ matrix.cibw_arch }}
 
       - name: Upload wheels to Github
         uses: actions/upload-artifact@v2
@@ -124,50 +138,50 @@ jobs:
           name: wheels
           path: ./wheelhouse/*.whl
 
-  upload-wheels:
-    name: Upload wheels to S3
-    runs-on: [ubuntu-latest]
-    needs: [build-wheels]
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: wheels
-
-      - uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-skip-session-tagging: true
-          aws-region: us-west-2
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
-          role-duration-seconds: 900
-
-      - name: Upload wheels to s3
-        run: |
-          zip ion-python-wheels ./*.whl
-          aws s3 mv ion-python-wheels.zip ${{ secrets.AWS_WHEELS_BUCKET_URL }} --acl bucket-owner-full-control
-
-      - name: Install the released wheels from PYPI
-        run: |
-          sleep 300s
-
-          for (( i=0; i<3; i++ ))
-          do
-            v=""
-
-            if ! (pip install --only-binary :all: amazon.ion==${GITHUB_REF##*/v}) then
-              echo "Unable to install the desired version"
-              sleep 120s
-              continue
-            fi
-
-            v=$( pip show amazon.ion | grep Version )
-            break
-          done
-
-          if [[ $v != "Version: ${GITHUB_REF##*/v}" ]]
-          then
-            echo "Exiting because unable to install the new version from PYPI"
-            exit 1
-          fi
+#  upload-wheels:
+#    name: Upload wheels to S3
+#    runs-on: [ubuntu-latest]
+#    needs: [build-wheels]
+#    steps:
+#      - uses: actions/download-artifact@v2
+#        with:
+#          name: wheels
+#
+#      - uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          role-skip-session-tagging: true
+#          aws-region: us-west-2
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+#          role-duration-seconds: 900
+#
+#      - name: Upload wheels to s3
+#        run: |
+#          zip ion-python-wheels ./*.whl
+#          aws s3 mv ion-python-wheels.zip ${{ secrets.AWS_WHEELS_BUCKET_URL }} --acl bucket-owner-full-control
+#
+#      - name: Install the released wheels from PYPI
+#        run: |
+#          sleep 300s
+#
+#          for (( i=0; i<3; i++ ))
+#          do
+#            v=""
+#
+#            if ! (pip install --only-binary :all: amazon.ion==${GITHUB_REF##*/v}) then
+#              echo "Unable to install the desired version"
+#              sleep 120s
+#              continue
+#            fi
+#
+#            v=$( pip show amazon.ion | grep Version )
+#            break
+#          done
+#
+#          if [[ $v != "Version: ${GITHUB_REF##*/v}" ]]
+#          then
+#            echo "Exiting because unable to install the new version from PYPI"
+#            exit 1
+#          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
           python-version: '3.10'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Build wheels
         run: python3 -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-*" # Only build wheels for c-python 3.9 to 3.11
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
 
       - name: Upload wheels to Github

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ iniconfig==1.1.1
 jsonconversion==0.2.12
 packaging==20.9
 pluggy==0.13.1
-py==1.10.0
+py==1.11.0
 pyparsing==2.4.7
 pytest==6.2.4
 pytest-runner==5.3.1


### PR DESCRIPTION
## Description 

This PR adds support for wheels on Python 3.11 and MacOS-arm64.

In detail, this PR:
1. Adds wheels for Python 3.11.
2. Adds wheels for MacOS-arm64.
3. Drops support for wheels built with Python 3.6 to 3.8.
4. Updates required dependencies and build tools.

## Test

1. A successful wheel build workflow from my fork can be found at: https://github.com/cheqianh/ion-python/actions/runs/7880967937.
2. All tests have passed on GitHub Actions 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
