### PR TITLE
Refactor simpleion pure-python load methods

### DIFF
--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -435,7 +435,7 @@ _FROM_ION_TYPE = [
 
 
 def _load_iteratively(reader):
-    containers: deque = deque()
+    containers = []
 
     while True:
         event = reader.send(NEXT_EVENT)


### PR DESCRIPTION
This change removes some duplication in the simpleion implementation.

Before this change the _load and _load_iteratively methods were near
duplicates and used the python call stack for maintaining the Ion
container stack.

After this change _load is removed in favor of _load_iteratively which
uses a deque to maintain the container stack.

It also factors out the handling of the single_value and parse_eagerly
flags which was also nearly duplicated between the ionc and
pure-python usages.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
