### PR TITLE
Add dependabot configuration for keeping dependencies current

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,20 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    # Group all updates to PIP dependencies into a once-weekly PR
     schedule:
-      interval: "daily"
+      interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      pip-dependencies:
+        patterns:
+          - '*'
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      github-action-dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
This change adds a Dependabot[1] configuration to keep dependencies up-to-date. The routine will check files like https://github.com/amazon-ion/ion-python/blob/master/requirements.txt for any updates.

[1] https://docs.github.com/en/code-security/dependabot

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.