### PR TITLE
Set update types (minor, patch) in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     open-pull-requests-limit: 1
     groups:
       pip-dependencies:
+        applies-to: version-updates
+        update-types: [minor, patch]
         patterns:
           - '*'
   - package-ecosystem: github-actions
@@ -17,5 +19,7 @@ updates:
     open-pull-requests-limit: 1
     groups:
       github-action-dependencies:
+        applies-to: version-updates
+        update-types: [minor, patch]
         patterns:
           - '*'


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

Updates the dependabot config so that dependabot won't throw a bunch of major version updates into it's regularly scheduled PRs.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
