### PR TITLE
Remove text_buffer_size_limit decref

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -1506,7 +1506,6 @@ PyObject* ionc_read(PyObject* self, PyObject *args, PyObject *kwds) {
     if (text_buffer_size_limit != Py_None) {
         int symbol_threshold = PyLong_AsLong(text_buffer_size_limit);
         iterator->_reader_options.symbol_threshold = symbol_threshold;
-        Py_XDECREF(text_buffer_size_limit);
     }
 
     IONCHECK(ion_reader_open_stream(


### PR DESCRIPTION
*Issue #, if available:* #347

*Description of changes:*
Prior to this PR the `ionc_read` function was decrementing the reference count of the `text_buffer_size_limit` argument resulting in a premature free, that could lead to improper memory access.

This PR removes that reference decrement.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
