### PR TITLE
feat: Add `trailing_commas` to `dump`/`dumps`

### DIFF
--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -477,13 +477,13 @@ def _load(out, reader, end_type=IonEventType.STREAM_END, in_struct=False):
         event = reader.send(NEXT_EVENT)
 
 
-def dump_extension(obj, fp, binary=True, sequence_as_stream=False, tuple_as_sexp=False, omit_version_marker=False,
-                   trailing_commas=False):
+def dump_extension(obj, fp, binary=True, sequence_as_stream=False, tuple_as_sexp=False, omit_version_marker=False):
     """C-extension implementation. Users should prefer to call ``dump``."""
 
-    res = ionc.ionc_write(obj, binary, sequence_as_stream, tuple_as_sexp, trailing_commas)
+    res = ionc.ionc_write(obj, binary, sequence_as_stream, tuple_as_sexp)
 
-    # TODO support "omit_version_marker" rather than hacking.
+    # TODO: support "omit_version_marker" rather than hacking.
+    # TODO: support "trailing_commas" (support is not included in the C code).
     if not binary and not omit_version_marker:
         res = b'$ion_1_0 ' + res
     fp.write(res)

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -163,25 +163,6 @@ def dumps(obj, imports=None, binary=True, sequence_as_stream=False,
         ret_val = ret_val.decode('utf-8')
     return ret_val
 
-"""
-import amazon.ion.simpleion as ion
-
-x = eval('''
-{
-   'foo': 1,
-   'bar': [
-      2,
-      3,
-      4
-   ],
-   'baz': {
-      'quux': 'whiz'
-   }
-}
-''')
-
-print(ion.dumps(x, binary=False, omit_version_marker=True, indent=u'   ', trailing_commas=True))
-"""
 
 class IonPyValueModel(IntFlag):
     """Flags to control the types of values that are emitted from load(s).

--- a/amazon/ion/writer_text.py
+++ b/amazon/ion/writer_text.py
@@ -369,7 +369,7 @@ def _raw_writer_coroutine(depth=0, container_event=None, whence=None, indent=Non
         ion_event, self = (yield transition)
         delegate = self
 
-        if has_written_values and (trailing_commas or not ion_event.event_type.ends_container):
+        if has_written_values and ((indent and trailing_commas) or not ion_event.event_type.ends_container):
             # TODO This will always emit a delimiter for containers--should make it not do that.
             # Write the delimiter for the next value.
             if depth == 0:

--- a/amazon/ion/writer_text.py
+++ b/amazon/ion/writer_text.py
@@ -359,7 +359,7 @@ _serialize_container_delimiter_pretty = _serialize_container_factory('delimiter'
 
 
 @coroutine
-def _raw_writer_coroutine(depth=0, container_event=None, whence=None, indent=None):
+def _raw_writer_coroutine(depth=0, container_event=None, whence=None, indent=None, trailing_commas=False):
     pretty = indent is not None
     serialize_container_delimiter = \
             _serialize_container_delimiter_pretty if pretty else _serialize_container_delimiter_normal
@@ -369,7 +369,7 @@ def _raw_writer_coroutine(depth=0, container_event=None, whence=None, indent=Non
         ion_event, self = (yield transition)
         delegate = self
 
-        if has_written_values and not ion_event.event_type.ends_container:
+        if has_written_values and (trailing_commas or not ion_event.event_type.ends_container):
             # TODO This will always emit a delimiter for containers--should make it not do that.
             # Write the delimiter for the next value.
             if depth == 0:
@@ -402,7 +402,8 @@ def _raw_writer_coroutine(depth=0, container_event=None, whence=None, indent=Non
 
         if ion_event.event_type is IonEventType.CONTAINER_START:
             writer_event = DataEvent(WriteEventType.NEEDS_INPUT, _serialize_container_start(ion_event))
-            delegate = _raw_writer_coroutine(depth + 1, ion_event, self, indent=indent)
+            delegate = _raw_writer_coroutine(depth + 1, ion_event, self, indent=indent,
+                                             trailing_commas=trailing_commas)
         elif depth == 0:
             # Serialize at the top-level.
             if ion_event.event_type is IonEventType.STREAM_END:
@@ -429,7 +430,7 @@ def _raw_writer_coroutine(depth=0, container_event=None, whence=None, indent=Non
 
 
 # TODO Add options for text formatting.
-def raw_writer(indent=None):
+def raw_writer(indent=None, trailing_commas=False):
     """Returns a raw text writer co-routine.
 
     Yields:
@@ -447,7 +448,7 @@ def raw_writer(indent=None):
     # of writing (Dec 2022).
     indent_bytes = indent.encode("UTF-8") if isinstance(indent, str) else indent
 
-    return writer_trampoline(_raw_writer_coroutine(indent=indent_bytes))
+    return writer_trampoline(_raw_writer_coroutine(indent=indent_bytes, trailing_commas=trailing_commas))
 
 # TODO Determine if we need to do anything special for non-raw writer.  Validation?
 text_writer = raw_writer

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -642,9 +642,9 @@ def test_unknown_object_type_fails(is_binary):
 class PrettyPrintParams(NamedTuple):
     ion_text: str
     indent: str
-    trailing_commas = False
     exact_text: Optional[str] = None
     regexes: Sequence = []
+    trailing_commas: bool = False
 
 @parametrize(
         PrettyPrintParams(ion_text='a', indent='  ', exact_text="$ion_1_0\na"),
@@ -687,9 +687,10 @@ def test_pretty_print(p):
     if c_ext:
         # TODO support pretty print for C extension.
         return
-    ion_text, indent, exact_text, regexes = p
+    ion_text, indent, exact_text, regexes, trailing_commas = p
     ion_value = loads(ion_text)
-    actual_pretty_ion_text = dumps(ion_value, binary=False, indent=indent)
+    actual_pretty_ion_text = dumps(ion_value, binary=False, indent=indent,
+                                   trailing_commas=trailing_commas)
     if exact_text is not None:
         assert actual_pretty_ion_text == exact_text
     for regex_str in regexes:

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -675,13 +675,13 @@ class PrettyPrintParams(NamedTuple):
                           indent=None, trailing_commas=True, # not pretty print
                           exact_text="$ion_1_0 [a,b,chair::2008-08-08T]"),
         PrettyPrintParams(ion_text='[apple, {roof: false}]', indent='\t', trailing_commas=True,
-                          exact_text="$ion_1_0\n[\n\tapple,\n\t{\n\t\troof: false,\n\t}\n]"),
+                          exact_text="$ion_1_0\n[\n\tapple,\n\t{\n\t\troof: false,\n\t},\n]"),
         PrettyPrintParams(ion_text='[apple, "banana", {roof: false}]', indent='\t', trailing_commas=True,
-                          exact_text="$ion_1_0\n[\n\tapple,\n\t\"banana\",\n\t{\n\t\troof: false,\n\t}\n]"),
+                          exact_text="$ion_1_0\n[\n\tapple,\n\t\"banana\",\n\t{\n\t\troof: false,\n\t},\n]"),
         PrettyPrintParams(ion_text='[apple, {roof: false, walls:4, door: wood::large::true}]', indent='\t',
                           trailing_commas=True,
                           regexes=["\\A\\$ion_1_0\n\\[\n\tapple,\n\t\\{", "\n\t\tdoor: wood::large::true,\n",
-                                   "\n\t\troof: false,\n", "\n\t\twalls: 4,\n", "\n\t\\}\n\\]\\Z"])
+                                   "\n\t\troof: false,\n", "\n\t\twalls: 4,\n", "\n\t\\},\n\\]\\Z"])
         )
 def test_pretty_print(p):
     if c_ext:

--- a/tests/test_writer_text.py
+++ b/tests/test_writer_text.py
@@ -302,7 +302,7 @@ def test_quote_symbols(p):
 
 @parametrize(
     ('    ', True),
-    ('   ', False)
+    ('   ', False),
     (None, True),
     (None, False))
 def test_trailing_commas(p):

--- a/tests/test_writer_text.py
+++ b/tests/test_writer_text.py
@@ -217,6 +217,7 @@ def new_writer():
 def test_raw_writer(p):
     assert_writer_events(p, new_writer)
 
+
 @parametrize(
         (None, True),
         ('', True),
@@ -249,6 +250,7 @@ class _P_Q(NamedTuple):
     backslash_required: bool = False
 
     pass
+
 
 @parametrize(
         _P_Q('a', False),
@@ -296,3 +298,19 @@ def test_quote_symbols(p):
     assert needs_quotes == quoted
     assert len(ion_value.ion_annotations) == 1
     assert ion_value.ion_annotations[0].text == symbol_text
+
+
+@parametrize(
+    ('    ', True),
+    ('   ', False)
+    (None, True),
+    (None, False))
+def test_trailing_commas(p):
+    indent, trailing_commas = p
+
+    # Ensure raw_writer can handle trailing_commas value with indent value for all value combinations.
+    raw_writer(indent, trailing_commas)
+
+    # Ensure that a value dumped using the indent and trailing_commas values can be successfully loaded.
+    ion_val = loads('[a, {x:2, y: height::17}]')
+    assert ion_val == loads(dumps(ion_val, binary=False, indent=indent, trailing_commas=trailing_commas))


### PR DESCRIPTION
*Issue #, if available:*
[Issue # 370](https://github.com/amazon-ion/ion-python/issues/370)

*Description of changes:*

Add an optional boolean argument `trailing_commas` to the `dump` and `dumps` methods in `simpleion`. Default: False.

When `trailing_commas=True`, and when `indent` is not `None`, this causes `dump[s]` to include a comma on the last item in a container.

**Note:** Since the C module already **does not support pretty printing**, this flag does nothing when using the C module.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.