### PR TITLE
chore: Update README to reflect the need for an old enough setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ python3 -m venv ./venv
 ...
 $ . venv/bin/activate
 $ pip install -U pip
-$ pip install -U setuptools
+$ pip install -U 'setuptools<71.0.0'
 $ pip install -r requirements.txt
 $ pip install -e .
 ```


### PR DESCRIPTION
*Issue #, if available:*

No issue assigned, but problem identified during the course of working on PR #372 for Issue #370.

*Description of changes:*

`setuptools.command.test` was removed in setuptools 72.x, so we can't use 72.x or newer without updating our ion-python's build/test setup. In addition, there was a breaking change, it seems, in 71.x, to `canonicalize_version()`.

By selecting setuptools **prior** to 71.0.0, the build and tests run successfully.

Errors encountered:

With setuptools 72.x:
```
...
    import setuptools.command.test as orig
ModuleNotFoundError: No module named 'setuptools.command.test'
```

With setuptools 71.x:
```
...
TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.