### PR TITLE
Fix invalid memory access in ionc_write

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -776,8 +776,8 @@ static iERR _ionc_write(hWRITER writer, PyObject* objs, PyObject* tuple_as_sexp,
  */
 static PyObject* ionc_write(PyObject *self, PyObject *args, PyObject *kwds) {
     iENTER;
-    PyObject *obj, *binary, *sequence_as_stream, *tuple_as_sexp;
-    ION_STREAM  *ion_stream = NULL;
+    PyObject *obj=NULL, *binary=NULL, *sequence_as_stream=NULL, *tuple_as_sexp=NULL;
+    ION_STREAM *ion_stream = NULL;
     BYTE* buf = NULL;
     hWRITER writer = NULL;
     static char *kwlist[] = {"obj", "binary", "sequence_as_stream", "tuple_as_sexp", NULL};
@@ -858,10 +858,10 @@ fail:
         ion_stream_close(ion_stream);
     }
     PyMem_Free(buf);
-    Py_DECREF(obj);
-    Py_DECREF(binary);
-    Py_DECREF(sequence_as_stream);
-    Py_DECREF(tuple_as_sexp);
+    Py_XDECREF(obj);
+    Py_XDECREF(binary);
+    Py_XDECREF(sequence_as_stream);
+    Py_XDECREF(tuple_as_sexp);
 
     PyObject* exception = NULL;
     if (err == IERR_INVALID_STATE) {

--- a/tests/test_reader_base.py
+++ b/tests/test_reader_base.py
@@ -238,3 +238,16 @@ def test_blocking_reader(p):
         else:
             actual = reader.send(input)
             assert expected == actual
+
+# Simple test to make sure that our C extension returns a proper exception if we give it unexpected parameters.
+def test_ionc_reader_fails_graceful():
+    from amazon.ion.simpleion import c_ext
+    from amazon.ion.exceptions import IonException
+    from pytest import raises
+
+    if c_ext:
+        from amazon.ion import ionc
+        with raises(IonException) as e_info:
+            ionc.ionc_read(None, 0, None, None) # Invalid argument
+        # Exceptions don't compare eq..
+        assert str(e_info.value) == str(IonException('IERR_INVALID_ARG ')) # Space is added when the error is thrown.

--- a/tests/test_reader_base.py
+++ b/tests/test_reader_base.py
@@ -245,9 +245,11 @@ def test_ionc_reader_fails_graceful():
     from amazon.ion.exceptions import IonException
     from pytest import raises
 
-    if c_ext:
+    try:
         from amazon.ion import ionc
         with raises(IonException) as e_info:
             ionc.ionc_read(None, 0, None, None) # Invalid argument
         # Exceptions don't compare eq..
         assert str(e_info.value) == str(IonException('IERR_INVALID_ARG ')) # Space is added when the error is thrown.
+    except ImportError:
+        pass

--- a/tests/test_writer_base.py
+++ b/tests/test_writer_base.py
@@ -134,3 +134,17 @@ def test_blocking_writer(p):
         result_type = writer.send(None)
         assert isinstance(result_type, WriteEventType) and result_type is not WriteEventType.HAS_PENDING
     assert p.expected == buf.getvalue()
+
+
+# Simple test to make sure that our C extension returns a proper exception if we give it unexpected parameters.
+def test_ionc_writer_fails_graceful():
+    from amazon.ion.simpleion import c_ext
+    from amazon.ion.exceptions import IonException
+    from pytest import raises
+
+    if c_ext:
+        from amazon.ion import ionc
+        with raises(IonException) as e_info:
+            ionc.ionc_write(None, True, False, False, None) # Invalid argument
+        # Exceptions don't compare eq..
+        assert str(e_info.value) == str(IonException('IERR_INVALID_ARG ')) # Space is added when the error is thrown.

--- a/tests/test_writer_base.py
+++ b/tests/test_writer_base.py
@@ -138,13 +138,14 @@ def test_blocking_writer(p):
 
 # Simple test to make sure that our C extension returns a proper exception if we give it unexpected parameters.
 def test_ionc_writer_fails_graceful():
-    from amazon.ion.simpleion import c_ext
     from amazon.ion.exceptions import IonException
     from pytest import raises
 
-    if c_ext:
+    try:
         from amazon.ion import ionc
         with raises(IonException) as e_info:
             ionc.ionc_write(None, True, False, False, None) # Invalid argument
         # Exceptions don't compare eq..
         assert str(e_info.value) == str(IonException('IERR_INVALID_ARG ')) # Space is added when the error is thrown.
+    except ImportError:
+        pass


### PR DESCRIPTION
*Issue #, if available:* #375

*Description of changes:*
The ionc extension had a few uninitialized pointers defined in `ionc_write` that would get `Py_DECREF`'d when the arguments provided where invalid. This was found with the feature added with #372, when an extra parameter was passed to track whether to print trialing commas or not.

This PR initializes the values to NULL and changes the `Py_DECREF` to `Py_XDECREF` because `Py_DECREF` doesn't handle NULL values. Unit tests were also added to ensure we're returning an exception and not blowing up in these cases.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
