### PR TITLE
Remove pypy from benchmarking, and split requirements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,13 +24,14 @@ jobs:
       - run: pip install --upgrade setuptools
       - run: pip install -r requirements.txt
       - run: pip install -e .
-      - run: py.test
+      # Run our tests, but do not run the benchmark tests since they pull in libraries that do not have pypy support.
+      - run: py.test --ignore tests/test_benchmark_cli.py --ignore tests/test_benchmark_spec.py
 
   test-windows:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.10' ]
+        python-version: ['3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.10']
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -44,4 +45,5 @@ jobs:
       - run: pip install --upgrade setuptools
       - run: pip install -r requirements.txt
       - run: pip install -e .
-      - run: py.test
+      # Run our tests, but do not run the benchmark tests since they pull in libraries that do not have pypy support.
+      - run: py.test --ignore tests/test_benchmark_cli.py --ignore tests/test_benchmark_spec.py

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -61,7 +61,8 @@ jobs:
             **/requirements.txt
             **/requirements_benchmark.txt
       - run: |
-          pip install -r requirements.txt -r requirements_benchmark.txt
+          pip install -r requirements.txt
+          [ -e "requirements_benchmark.txt" ] && pip install -r requirements_benchmark.txt # include benchmark requirements if they exist.
           # TODO: See if there's a way to cache the ion-c build output if it hasn't changed
 
   detect-regression:
@@ -108,7 +109,8 @@ jobs:
       - name: Create a virtual environment
         working-directory: ./baseline
         run: |
-          pip install -r requirements.txt -r requirements_benchmark.txt
+          pip install -r requirements.txt
+          [ -e "requirements_benchmark.txt" ] && pip install -r requirements_benchmark.txt # include benchmark requirements if they exist.
           pip install .
       - name: Run baseline performance benchmark
         id: 'baseline'
@@ -126,7 +128,8 @@ jobs:
       - name: Create a virtual environment and setup the package
         working-directory: ./new
         run: |
-          pip install -r requirements.txt -r requirements_benchmark.txt
+          pip install -r requirements.txt
+          [ -e "requirements_benchmark.txt" ] && pip install -r requirements_benchmark.txt # include benchmark requirements if they exist.
           pip install .
       - name: Run new performance benchmark
         id: 'new'

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -56,9 +56,11 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
-          cache-dependency-path: '**/requirements.txt'
+          cache-dependency-path: |
+            **/requirements.txt
+            **/requirements_benchmark.txt
       - run: |
-          pip install -r requirements.txt
+          pip install -r requirements.txt -r requirements_benchmark.txt
           # TODO: See if there's a way to cache the ion-c build output if it hasn't changed
 
   detect-regression:
@@ -67,7 +69,7 @@ jobs:
     needs: [generate-test-data, prepopulate-pip-cache]
     strategy:
       matrix:
-        python-version: ['3.9', '3.11', 'pypy-3.8', 'pypy-3.10']
+        python-version: ['3.9', '3.11']
         test-data: ['nestedStruct', 'nestedList', 'sexp', 'realWorldDataSchema01', 'realWorldDataSchema02', 'realWorldDataSchema03']
       fail-fast: false
     steps:
@@ -91,7 +93,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/requirements.txt'
+          cache-dependency-path: |
+            **/requirements.txt
+            **/requirements_benchmark.txt
 
       - name: Download Test Data
         id: 'download'
@@ -103,7 +107,7 @@ jobs:
       - name: Create a virtual environment
         working-directory: ./baseline
         run: |
-          pip install -r requirements.txt
+          pip install -r requirements.txt -r requirements_benchmark.txt
           pip install .
       - name: Run baseline performance benchmark
         id: 'baseline'
@@ -121,7 +125,7 @@ jobs:
       - name: Create a virtual environment and setup the package
         working-directory: ./new
         run: |
-          pip install -r requirements.txt
+          pip install -r requirements.txt -r requirements_benchmark.txt
           pip install .
       - name: Run new performance benchmark
         id: 'new'

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -5,6 +5,7 @@ on:
     paths:
       # Workflow will only run if something in this path is changed
       - 'amazon/**'
+      - '.github/workflows/performance-regression.yml' # Also trigger if the workflow itself changes.
 
 env:
   report_statistics: 'file_size,time_mean,time_error,ops/s_mean,ops/s_error,memory_usage_peak'

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,3 @@ docopt==0.6.2
 tabulate==0.9.0
 simplejson~=3.18.3
 six~=1.16.0
-cbor~=1.0.0
-cbor2~=5.4.6
-python-rapidjson~=1.19
-ujson~=5.7.0
-protobuf>=4.0.0

--- a/requirements_benchmark.txt
+++ b/requirements_benchmark.txt
@@ -1,0 +1,5 @@
+cbor~=1.0.0
+cbor2~=5.4.6
+python-rapidjson~=1.19
+ujson~=5.7.0
+protobuf>=4.0.0


### PR DESCRIPTION
*Issue #, if available:* #377

*Description of changes:*
This PR removes pypy from the performance regression workflows. It also removes the benchmark cli tests, and benchmark spec tests from the main build & tests workflows so that we can eliminate other format libraries that may not support pypy from our ci checks, in order to continue validating pypy correctness.

`requirements.txt` has been split and `requirements_benchmark.txt` has been populated with the dependencies needed only for benchmarking. When running the performance regression workflows, or local benchmarking efforts this new requirements file will need to be installed as well.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
