### PR TITLE
Install benchmark requirements during release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         run: git submodule init && git submodule update && python3 -m venv ./venv && . venv/bin/activate
       - run: pip install --upgrade setuptools
       - run: pip install -r requirements.txt
+      - run: [ -e "requirements_benchmark.txt" ] && pip install -r requirements_benchmark.txt # include benchmark requirements if they exist.
       - run: pip install -e .
       - run: py.test
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Missed the release workflow when updating unit testing to split benchmarks from functional tests. This PR adds the installation so that a bare `py.test` should test and validate all functionality.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
