### PR TITLE
Remove benchmark related tests since they can't be run in pypy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,9 @@ jobs:
         run: |
           pip install --upgrade setuptools
           pip install -r requirements.txt
-          [ -e "requirements_benchmark.txt" ] && pip install -r requirements_benchmark.txt # include benchmark requirements if they exist.
           pip install -e .
       - name: Run Tests
-        run: py.test
+        run: py.test --ignore tests/test_benchmark_cli.py --ignore tests/test_benchmark_spec.py
 
   source-distribution:
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR ignores benchmark related tests during the release workflow's test phase. When testing in pypy we are unable to run benchmark related tests, or the benchmark CLI, due to dependencies that do not support pypy. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
