### PR TITLE
Fix release workflow, externally managed environment error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,24 +111,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up pip and setuptools
-        run: |
-          pip3 install -U pip
-          pip3 install -U setuptools
-
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
-      - name: Install cibuildwheel
-        run: python3 -m pip install cibuildwheel==2.16.5
-
-      - name: Build wheels
-        run: python3 -m cibuildwheel --output-dir wheelhouse
+      - name: Build Wheels
+        uses: pypa/cibuildwheel@v2.21.3
         env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-*" # Only build wheels for c-python 3.9 to 3.11
+          CIBW_BUILD: "cp39-* cp310-* cp311-*"
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
 
       - name: Upload wheels to Github


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
With the release of 0.13.0 a few maintenance issues have popped up with the release workflow. The latest is a change to the MacOS runners which introduces [PEP-668](https://peps.python.org/pep-0668/), disallowing pip to be used directly on a system install. ([Example](https://github.com/amazon-ion/ion-python/actions/runs/11807251033/job/32893620133) failed run)

Most of our workflows use virtual environments, which satisfies PEP-668, however the release workflow does not use a virtual environment when building wheels with cibuildwheel.

This PR updates the release workflow to lean on the cibuildwheel GHA for building our wheels, rather than manually installing and running cibuildwheel. This simplifies the workflow, and allows the cibuildwheel version to be maintained by dependabot. Internally cibuildwheel's GHA uses pipx which satisfies the PEP-668 issue.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
