### PR TITLE
Address macos-latest update to arm-based MacOS 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
       matrix:
         include:
           # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip for more details.
-          - os: macos-latest
+          - os: macos-13 # macos-13 is the last non-large x86-based runner. Need to look into cross-compiling.
             arch: x86_64
             cibw_arch: "x86_64"
           - os: macos-14  # https://github.com/actions/runner-images?tab=readme-ov-file#available-images


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Prior to this PR the release workflow was relying on the `macos-latest` runner in order to build `x86_64` wheels. Since our 0.12.0 release, the `macos-latest` runner has become an alias for `macos-14`, which is an arm-based runner. This change causes our x86 wheel build to [fail](https://github.com/amazon-ion/ion-python/actions/runs/11827991785/job/32957301528#step:3:243).
 
Currently, `macos-13` is the only standard x86-based MacOS runner.

This PR changes our use of `macos-latest` to `macos-13` in order to regail x86 build capabilities. A future task should be taken up to use Arm-based runners to cross-compile x86. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
