### PR TITLE
Fix duplicate named archives in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Upload wheels to Github
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   upload-wheels:
@@ -130,7 +130,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
+          merge-multiple: true
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
The recent update to upload-artifact and download-artifact GHAs changed the behavior around artifact naming. Previously multiple jobs could upload artifacts with the same name, and they would be merged together into a single artifact. With the newer versions jobs cannot upload artifacts with the same name, and must be given a unique name ([example](https://github.com/amazon-ion/ion-python/actions/runs/11829052156/job/32960265700#step:4:13) failure).

This PR adjusts the uploaded artifact's name to be unique per OS/Architecture build, and updates the `upload-wheels` job to handle the new names, and merge the individual files into the same directory.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
