### PR TITLE
Setup QEMU for Arm wheel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,11 +111,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU for Linux Builds
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
       - name: Build Wheels
         uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: "cp39-* cp310-* cp311-*"
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
+          CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
 
       - name: Upload wheels to Github
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR adds QEMU configuration back into the release workflow. The cibuildwheel action we rely on does not set qemu up itself, and will only use it if it exists prior to the action running.

I had some issues testing this out to confirm it works. On my setup QEMU keeps segfaulting while building ion-c at various places. I wasn't able to track the issue down to a root cause, and the crashes would occur in different places, which lead me to believe that something may have been off with the containers, or otherwise how `act` was setting up the environment.

Prior to moving to cibuildwheel's GHA, we manually ran cibuildwheel with QEMU configured this same way.
In addition to the QEMU configuration itself, I also added the linux specific cibuildwheel environment variable, which seems to be needed by the GHA to use QEMU.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
