### PR TITLE
Update release workflow to use PyPI's trusted publisher support.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           do
             v=""
 
-            if ! (pip install --no-binary :all: amazon.ion==${GITHUB_REF##*/v}) then
+            if ! (pip install --no-binary :all: "amazon.ion==${GITHUB_REF##*/v}") then
               echo "Unable to install the desired version"
               sleep 120s
               continue
@@ -120,7 +120,11 @@ jobs:
       - name: Build Wheels
         uses: pypa/cibuildwheel@v2.22.0
         env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-*"
+          # See the following for the status of python versions (ie. what's EoL'd, security only, etc):
+          # https://devguide.python.org/versions/
+          #
+          # At the time of writing, anything older than 3.9 is end-of-life.
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
 
@@ -131,29 +135,20 @@ jobs:
           path: ./wheelhouse/*.whl
 
   upload-wheels:
-    name: Upload wheels to S3
+    name: Release wheels to PyPI
     runs-on: [ubuntu-latest]
     needs: [build-wheels]
+    permissions:
+      id-token: write # Needed for PyPi trusted publishing
     steps:
       - uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
+          path: ./dist
           merge-multiple: true
 
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-skip-session-tagging: true
-          aws-region: us-west-2
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
-          role-duration-seconds: 900
-
-      - name: Upload wheels to s3
-        run: |
-          zip ion-python-wheels ./*.whl
-          aws s3 mv ion-python-wheels.zip ${{ secrets.AWS_WHEELS_BUCKET_URL }} --acl bucket-owner-full-control
+      - name: Publish Package to PyPI
+        uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # release/v1.12
 
       - name: Install the released wheels from PYPI
         run: |
@@ -163,7 +158,7 @@ jobs:
           do
             v=""
 
-            if ! (pip install --only-binary :all: amazon.ion==${GITHUB_REF##*/v}) then
+            if ! (pip install --only-binary :all: "amazon.ion==${GITHUB_REF##*/v}") then
               echo "Unable to install the desired version"
               sleep 120s
               continue


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Prior to this PR the release workflow would build our wheels and upload them to S3, where a code pipeline would upload them to PyPI. Last year, PyPI removed the ability to upload wheels using user/pass for auth, and required either an API key, or configuring a Trusted Publisher.

This PR updates the release workflow to use PyPI's trusted publisher via Github. Rather than uploading the wheels to S3, and uploading them via the code pipeline with a secret key, we've configured our PyPI project to trust Github's OIDC provider. In our workflow we can request a token from Github (via the `pypa/gh-action-pypi-publish` action) which will be signed with Github's key, and verified by PyPI. The token contains claims containing the repo and workflow that is attempting to authenticate. Our PyPI project is configured to only allow the `amazon-ion/ion-python` repo and `release.yml` workflow, to push new wheels. By using this method, we do not have to store any secrets for our PyPI account, and can simplify our release process.

In addition to this change, I've addressed some `actionlint` warnings regarding shell quoting, and added python 3.12 and 3.13 to the versions cibuildwheel will build for.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
