### PR TITLE
Update jsonconversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ urls = { "Documentation" = "https://ion-python.readthedocs.io/en/latest/?badge=l
 dependencies = [
     "attrs==21.2.0",
     "setuptools==71.0.0",    # Needed for jsonconversion, it seems
-    "jsonconversion==0.2.13", # 1.0.1 tightens the requirements for pytest, and 1.0.0 is broken.
+    "jsonconversion==1.0.3",
     "pyparsing==3.0.0",
 ]
 dynamic = ["version", "description"]


### PR DESCRIPTION
Updating jsonconversion past the broken version and the restrictive versions holding back pytest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
