### PR TITLE
Bump minimum python version to 3.9.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.10']
-        os: [ macos-latest, ubuntu-latest ]
+        # Python maintains 5 versions, along with the to-be-released version. Every October, this changes.
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.8', 'pypy-3.10']
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -23,26 +24,5 @@ jobs:
         run: git submodule init && git submodule update && python3 -m venv ./venv && . venv/bin/activate
       - run: python -m pip install build
       - run: python -m pip install '.[test]'
-      # Run our tests, but do not run the benchmark tests since they pull in libraries that do not have pypy support.
-      - run: py.test --ignore tests/test_benchmark_cli.py --ignore tests/test_benchmark_spec.py
-
-  test-windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.10']
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Create a virtual environment
-        run: git submodule init && git submodule update && python3 -m venv ./venv && . venv/Scripts/activate
-      - run: python -m pip install build
-      - run: python -m build
-      - run: python -m pip install -e '.[test]'
       # Run our tests, but do not run the benchmark tests since they pull in libraries that do not have pypy support.
       - run: py.test --ignore tests/test_benchmark_cli.py --ignore tests/test_benchmark_spec.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # Python maintains 5 versions, along with the to-be-released version. Every October, this changes.
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10', 'pypy-3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
         os: [ macos-latest, ubuntu-latest, windows-latest ]
       fail-fast: false
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # Python maintains 5 versions, along with the to-be-released version. Every October, this changes.
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.8', 'pypy-3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10', 'pypy-3.11']
         os: [ macos-latest, ubuntu-latest, windows-latest ]
       fail-fast: false
     steps:
@@ -21,7 +21,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Create a virtual environment
-        run: git submodule init && git submodule update && python3 -m venv ./venv && . venv/bin/activate
+        run: git submodule init && git submodule update && python3 -m venv ./venv
+
+      - name: Activate Virtual Environment for Windows.
+        if: matrix.os == 'windows-latest'
+        run: . venv/Scripts/activate
+      - name: Activate Virtual Environment for Linux and Mac
+        if: matrix.os != 'windows-latest'
+        run: . venv/bin/activate
+
       - run: python -m pip install build
       - run: python -m pip install '.[test]'
       # Run our tests, but do not run the benchmark tests since they pull in libraries that do not have pypy support.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.8']
     steps:
       - uses: actions/checkout@v4
       - name: Set up python

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,7 +54,7 @@
 * Add support for large decimals with >34 digits. (#293) 
 
 ### 0.11.1 (2023-10-09)
-* Drops the support for Python versions older than 3.8.
+* Drops the support for Python versions older than 3.7 (#292).
 
 ### 0.11.0 (2023-10-09)
 * Refactors the benchmark tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "amazon-ion"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { "file" = "LICENSE" }
 authors = [{ "name" = "Amazon Ion Team", "email" = "ion-team@amazon.com" }]
 keywords = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ testpaths = ["tests"]
 #  running our default unit tests (minus benchmarking related tests). This ensures that we
 #  can easily test against supported python versions.
 [tool.tox]
-envlist = ["py3.8", "py3.9", "pypy3"] # default environments to run.
+envlist = ["py3.9", "pypy3"] # default environments to run.
 
 [tool.tox.env_run_base]
 extras = ["test"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR bumps the minimum supported version of python to 3.9, dropping 3.8 which has now been EOL'd for 6 months.

In addition, this PR:
 * removes the 3.8 targets for both python and PyPy from our workflows
 * fixes a typo in the changelog that suggested 3.8 had been dropped over a year ago
 * adds 3.12 and 3.13 to the python versions tested in GHA CI/CD.
 * merges the windows & linux/mac GHA test jobs back together now that 3.8 is dropped (#308)

Since python versions reach end of life every October, it would be nice to have our tests testing against the current supported versions, as well as the latest dev version (currently 3.14). I started looking into adding a GHA job to test the latest dev version and not fail the build if it fails, as an early warning for potential python changes, but felt it went beyond the purpose of this PR.

Also, by dropping 3.8 support we're able to bump some of our dependencies. I didn't do this in this PR, but once this PR is merged #404 should be able to merge without issue.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
