### PR TITLE
Add configuration for readthedocs, and tweak sphinx settings to work with recent pyproject migration.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,8 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../src-python'))
 
+from amazon.ion import __version__
+
 
 # -- Project information -----------------------------------------------------
 
@@ -24,9 +26,9 @@ copyright = '2018, Amazon Ion Team'
 author = 'Amazon Ion Team'
 
 # The short X.Y version
-version = ''
+version = __version__
 # The full version, including alpha/beta/rc tags
-release = '0.3.2'
+release = version
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../'))
+sys.path.insert(0, os.path.abspath('../src-python'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-rtd-theme


### PR DESCRIPTION
*Issue #, if available:* #209

*Description of changes:*
In June 2021, the ion-python docs [started failing](https://app.readthedocs.org/projects/ion-python/builds/14027632/) due to pytest 6.2.4 not being found for python 2.7.

Issues with requirements while trying to run under python 2.7 continued until Oct 2023, when readthedocs started requiring projects to have a readthedocs configuration file in order to drive doc generation. Once this was enforced, the documentation build [started failing](https://app.readthedocs.org/projects/ion-python/builds/22147034/) for this reason.

This PR adds the `.readthedocs.yaml` configuration required by readthedocs.com, and updates the sphinx configuration in order to load the `amazon.ion` module after the migration to pyproject.

A new `requirements.txt` has been added to the doc/ directory, which includes the dependencies needed for generating the documentation. Since the last successful build, the theme we were using was taken out of sphinx, and is intended to be installed as needed. So that is currently the only package in the requirements file.

I've also updated the sphinx configuration script to pull the ion-python version from the amazon.ion module, rather than having to update another place when the version changes.

I've built the docs locally with sphinx, but cannot replicate the readthedocs process locally. Once this is merged, we'll have to wait and see if readthedocs picks it up automatically and if there are any other issues.

I've also noticed some markdown used in the comment docs, and sphinx is currently not configured to use markdown. A follow-up task might be to either switch to markdown, or update the comments.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
