### PR TITLE
Fix import of pytest's raises to newer(?) API.

### DIFF
--- a/tests/test_sliceable_buffer.py
+++ b/tests/test_sliceable_buffer.py
@@ -1,6 +1,6 @@
 from typing import NamedTuple, Sequence, Callable
 
-from _pytest.python_api import raises
+from pytest import raises
 
 from amazon.ion.sliceable_buffer import IncompleteReadError, SliceableBuffer
 from tests import parametrize


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Dependabot posted #416, which uncovered a weird import of pytest's `raises`. Looks like the API has changed with a recent release to no longer export raises there.

This PR adjusts the import to match the pytest API which should fix the dependabot PR.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
